### PR TITLE
Proof of concept gas metering

### DIFF
--- a/cli/src/commands/execute.rs
+++ b/cli/src/commands/execute.rs
@@ -113,7 +113,7 @@ impl ExecuteCmd {
     let start_time = Instant::now();
     let client = ExecutionClient::new();
     // no host interface needed for direct execution
-    let (output, _gas_left) = client.execute::<MockHost>(&elf, stdin, None, 0).unwrap();
+    let (output, _gas_left) = client.execute::<MockHost>(&elf, stdin, None, None).unwrap();
 
     let elapsed = elapsed(start_time.elapsed());
     let green = AnsiColor::Green.on_default().effects(Effects::BOLD);

--- a/cli/src/commands/execute.rs
+++ b/cli/src/commands/execute.rs
@@ -113,7 +113,7 @@ impl ExecuteCmd {
     let start_time = Instant::now();
     let client = ExecutionClient::new();
     // no host interface needed for direct execution
-    let output = client.execute::<MockHost>(&elf, stdin, None, 0).unwrap();
+    let (output, _gas_left) = client.execute::<MockHost>(&elf, stdin, None, 0).unwrap();
 
     let elapsed = elapsed(start_time.elapsed());
     let green = AnsiColor::Green.on_default().effects(Effects::BOLD);

--- a/cli/src/commands/execute.rs
+++ b/cli/src/commands/execute.rs
@@ -113,7 +113,7 @@ impl ExecuteCmd {
     let start_time = Instant::now();
     let client = ExecutionClient::new();
     // no host interface needed for direct execution
-    let output = client.execute::<MockHost>(&elf, stdin, None).unwrap();
+    let output = client.execute::<MockHost>(&elf, stdin, None, 0).unwrap();
 
     let elapsed = elapsed(start_time.elapsed());
     let green = AnsiColor::Green.on_default().effects(Effects::BOLD);

--- a/core/src/runtime/io.rs
+++ b/core/src/runtime/io.rs
@@ -89,7 +89,7 @@ pub mod tests {
     let points = points();
     runtime.write_stdin(&points.0);
     runtime.write_stdin(&points.1);
-    runtime.run().unwrap();
+    runtime.execute().unwrap();
     let added_point = runtime.read_public_values::<MyPointUnaligned>();
     assert_eq!(
       added_point,

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -752,7 +752,7 @@ where
 
     // Calculate remaining gas. If we spent too much gas, an error would already have been thrown and
     // we would never reach this code, hence the assertion.
-    let gas_left = self.gas_left();
+    let gas_left = if self.max_gas > 0 { self.gas_left() } else { 0 };
     Ok(u32::try_from(gas_left).expect("Gas conversion error"))
   }
 

--- a/core/src/runtime/state.rs
+++ b/core/src/runtime/state.rs
@@ -10,66 +10,55 @@ use super::MemoryRecord;
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ExecutionState {
-    /// The global clock keeps track of how many instrutions have been executed through all shards.
-    pub global_clk: u64,
+  /// The global clock keeps track of how many instrutions have been executed.
+  pub global_clk: u64,
 
-    /// The shard clock keeps track of how many shards have been executed.
-    pub current_shard: u32,
+  /// The clock increments by 4 (possibly more in syscalls) for each instruction that has been
+  /// executed.
+  pub clk: u32,
 
-    /// The clock increments by 4 (possibly more in syscalls) for each instruction that has been
-    /// executed in this shard.
-    pub clk: u32,
+  /// The program counter.
+  pub pc: u32,
 
-    /// The channel alternates between 0 and [crate::bytes::NUM_BYTE_LOOKUP_CHANNELS],
-    /// used to controll byte lookup multiplicity.
-    pub channel: u32,
+  /// The memory which instructions operate over.
+  pub memory: HashMap<u32, MemoryRecord, BuildNoHashHasher<u32>>,
 
-    /// The program counter.
-    pub pc: u32,
+  /// Uninitialized memory addresses that have a specific value they should be initialized with.
+  /// SyscallHintRead uses this to write hint data into uninitialized memory.
+  pub uninitialized_memory: HashMap<u32, u32, BuildNoHashHasher<u32>>,
 
-    /// The memory which instructions operate over. Values contain the memory value and last shard
-    /// + timestamp that each memory address was accessed.
-    pub memory: HashMap<u32, MemoryRecord, BuildNoHashHasher<u32>>,
+  /// A stream of input values (global to the entire program).
+  pub input_stream: Vec<Vec<u8>>,
 
-    /// Uninitialized memory addresses that have a specific value they should be initialized with.
-    /// SyscallHintRead uses this to write hint data into uninitialized memory.
-    pub uninitialized_memory: HashMap<u32, u32, BuildNoHashHasher<u32>>,
+  /// A ptr to the current position in the input stream incremented by HINT_READ opcode.
+  pub input_stream_ptr: usize,
 
-    /// A stream of input values (global to the entire program).
-    pub input_stream: Vec<Vec<u8>>,
+  /// A stream of public values from the program (global to entire program).
+  pub public_values_stream: Vec<u8>,
 
-    /// A ptr to the current position in the input stream incremented by HINT_READ opcode.
-    pub input_stream_ptr: usize,
-
-    /// A stream of public values from the program (global to entire program).
-    pub public_values_stream: Vec<u8>,
-
-    /// A ptr to the current position in the public values stream, incremented when reading from public_values_stream.
-    pub public_values_stream_ptr: usize,
+  /// A ptr to the current position in the public values stream, incremented when reading from public_values_stream.
+  pub public_values_stream_ptr: usize,
 }
 
 impl ExecutionState {
-    pub fn new(pc_start: u32) -> Self {
-        Self {
-            global_clk: 0,
-            // Start at shard 1 since shard 0 is reserved for memory initialization.
-            current_shard: 1,
-            clk: 0,
-            channel: 0,
-            pc: pc_start,
-            memory: HashMap::default(),
-            uninitialized_memory: HashMap::default(),
-            input_stream: Vec::new(),
-            input_stream_ptr: 0,
-            public_values_stream: Vec::new(),
-            public_values_stream_ptr: 0,
-        }
+  pub fn new(pc_start: u32) -> Self {
+    Self {
+      global_clk: 0,
+      clk: 0,
+      pc: pc_start,
+      memory: HashMap::default(),
+      uninitialized_memory: HashMap::default(),
+      input_stream: Vec::new(),
+      input_stream_ptr: 0,
+      public_values_stream: Vec::new(),
+      public_values_stream_ptr: 0,
     }
+  }
 }
 
 /// Holds data to track changes made to the runtime since a fork point.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ForkState {
-    /// Only contains the original memory values for addresses that have been modified
-    pub(crate) memory_diff: HashMap<u32, Option<MemoryRecord>, BuildNoHashHasher<u32>>,
+  /// Only contains the original memory values for addresses that have been modified
+  pub(crate) memory_diff: HashMap<u32, Option<MemoryRecord>, BuildNoHashHasher<u32>>,
 }

--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -103,10 +103,6 @@ where
     }
   }
 
-  pub fn current_channel(&self) -> u32 {
-    self.rt.state.channel
-  }
-
   pub fn mr(&mut self, addr: u32) -> (MemoryReadRecord, u32) {
     let record = self.rt.mr(addr, self.clk);
     (record, record.value)

--- a/core/src/runtime/utils.rs
+++ b/core/src/runtime/utils.rs
@@ -72,7 +72,8 @@ where
 
     if !self.unconstrained && self.state.global_clk % 10_000_000 == 0 {
       log::info!(
-        "clk = {} pc = 0x{:x?}",
+        "clk = {} global_clk = {} pc = 0x{:x?}",
+        self.state.clk,
         self.state.global_clk,
         self.state.pc
       );

--- a/core/src/utils/options.rs
+++ b/core/src/utils/options.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone, Copy)]
 pub struct AthenaCoreOpts {
-  max_gas: u32,
+  max_gas: Option<u32>,
 }
 
 impl AthenaCoreOpts {
@@ -16,20 +16,20 @@ impl AthenaCoreOpts {
     self
   }
 
-  pub fn max_gas(&self) -> u32 {
+  pub fn max_gas(&self) -> Option<u32> {
     self.max_gas
   }
 }
 
 impl Default for AthenaCoreOpts {
   fn default() -> Self {
-    Self { max_gas: 0 }
+    Self { max_gas: None }
   }
 }
 
 // Functional option for gas_metering
 pub fn with_max_gas(value: u32) -> impl FnOnce(&mut AthenaCoreOpts) {
   move |opts: &mut AthenaCoreOpts| {
-    opts.max_gas = value;
+    opts.max_gas = Some(value);
   }
 }

--- a/core/src/utils/options.rs
+++ b/core/src/utils/options.rs
@@ -1,10 +1,35 @@
 #[derive(Debug, Clone, Copy)]
 pub struct AthenaCoreOpts {
+  max_gas: u32,
+}
+
+impl AthenaCoreOpts {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  // Method to apply options
+  pub fn with_options(mut self, opts: impl IntoIterator<Item = impl FnOnce(&mut Self)>) -> Self {
+    for opt in opts {
+      opt(&mut self);
+    }
+    self
+  }
+
+  pub fn max_gas(&self) -> u32 {
+    self.max_gas
+  }
 }
 
 impl Default for AthenaCoreOpts {
-    fn default() -> Self {
-        Self {
-        }
-    }
+  fn default() -> Self {
+    Self { max_gas: 0 }
+  }
+}
+
+// Functional option for gas_metering
+pub fn with_max_gas(value: u32) -> impl FnOnce(&mut AthenaCoreOpts) {
+  move |opts: &mut AthenaCoreOpts| {
+    opts.max_gas = value;
+  }
 }

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -144,7 +144,7 @@ impl From<ffi::athcon_message> for AthenaMessageWrapper {
     AthenaMessageWrapper(AthenaMessage {
       kind: kind.0,
       depth: item.depth,
-      gas: item.gas,
+      gas: u32::try_from(item.gas).expect("Gas value out of range"),
       recipient: AddressWrapper::from(item.recipient).into(),
       sender: AddressWrapper::from(item.sender).into(),
       input_data,
@@ -170,7 +170,7 @@ impl From<AthenaMessageWrapper> for ffi::athcon_message {
     ffi::athcon_message {
       kind,
       depth: item.0.depth,
-      gas: item.0.gas,
+      gas: item.0.gas as i64,
       recipient: AddressWrapper(item.0.recipient).into(),
       sender: AddressWrapper(item.0.sender).into(),
       input_data,
@@ -196,7 +196,7 @@ impl From<&AthconExecutionMessage> for AthenaMessageWrapper {
     AthenaMessageWrapper(AthenaMessage {
       kind: kind.0,
       depth: item.depth(),
-      gas: item.gas(),
+      gas: u32::try_from(item.gas()).expect("Gas value out of range"),
       recipient: AddressWrapper::from(*item.recipient()).into(),
       sender: AddressWrapper::from(*item.sender()).into(),
       input_data: item.input().cloned(),
@@ -286,7 +286,7 @@ impl From<AthconExecutionResult> for ExecutionResultWrapper {
   fn from(result: AthconExecutionResult) -> Self {
     ExecutionResultWrapper(ExecutionResult::new(
       StatusCodeWrapper::from(result.status_code()).into(),
-      result.gas_left(),
+      u32::try_from(result.gas_left()).expect("Gas value out of range"),
       result.output().cloned(),
       result
         .create_address()
@@ -315,7 +315,7 @@ impl From<ExecutionResultWrapper> for ffi::athcon_result {
       core::ptr::NonNull::<u8>::dangling().as_ptr()
     };
 
-    let gas_left = value.0.gas_left;
+    let gas_left = value.0.gas_left as i64;
     let create_address = value.0.create_address.map_or_else(
       || ffi::athcon_address::default(),
       |address| AddressWrapper(address).into(),

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -493,7 +493,7 @@ pub fn vm_tests(vm_ptr: *mut ffi::athcon_vm) {
     let message = ::athcon_sys::athcon_message {
       kind: ::athcon_sys::athcon_call_kind::ATHCON_CALL,
       depth: 0,
-      gas: 0,
+      gas: 10000,
       recipient: ::athcon_sys::athcon_address::default(),
       sender: ::athcon_sys::athcon_address::default(),
       input_data: std::ptr::null(),

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -116,7 +116,7 @@ pub enum MessageKind {
 pub struct AthenaMessage {
   pub kind: MessageKind,
   pub depth: i32,
-  pub gas: i64,
+  pub gas: u32,
   pub recipient: Address,
   pub sender: Address,
   pub input_data: Option<Vec<u8>>,
@@ -128,7 +128,7 @@ impl AthenaMessage {
   pub fn new(
     kind: MessageKind,
     depth: i32,
-    gas: i64,
+    gas: u32,
     recipient: Address,
     sender: Address,
     input_data: Option<Vec<u8>>,
@@ -190,7 +190,7 @@ impl fmt::Display for StatusCode {
 #[derive(Debug)]
 pub struct ExecutionResult {
   pub status_code: StatusCode,
-  pub gas_left: i64,
+  pub gas_left: u32,
   pub output: Option<Vec<u8>>,
   pub create_address: Option<Address>,
 }
@@ -198,7 +198,7 @@ pub struct ExecutionResult {
 impl ExecutionResult {
   pub fn new(
     status_code: StatusCode,
-    gas_left: i64,
+    gas_left: u32,
     output: Option<Vec<u8>>,
     create_address: Option<Address>,
   ) -> Self {

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -118,14 +118,69 @@ mod tests {
   }
 
   #[test]
-  fn test_vm() {
+  #[should_panic]
+  fn test_empty_code() {
     // construct a mock host
     let host = MockHost::new(None);
     let host_provider = HostProvider::new(host);
+    let host_interface = Arc::new(RefCell::new(host_provider));
+
+    // construct a vm
+    AthenaVm::new().execute(
+      host_interface,
+      0,
+      AthenaMessage::new(
+        MessageKind::Call,
+        0,
+        1000,
+        Address::default(),
+        Address::default(),
+        None,
+        Balance::default(),
+        vec![],
+      ),
+      &[],
+    );
+  }
+
+  // #[test]
+  // fn test_minimal_elf() {
+  //   // construct a mock host
+  //   let host = MockHost::new(None);
+  //   let host_provider = HostProvider::new(host);
+  //   let host_interface = Arc::new(RefCell::new(host_provider));
+
+  //   // construct a vm
+  //   let vm = AthenaVm::new();
+
+  //   let execution_result = vm.execute(
+  //     host_interface,
+  //     0,
+  //     AthenaMessage::new(
+  //       MessageKind::Call,
+  //       0,
+  //       1000,
+  //       Address::default(),
+  //       Address::default(),
+  //       None,
+  //       Balance::default(),
+  //       vec![],
+  //     ),
+  //     include_bytes!("../../tests/minimal/elf/minimal-test.elf"),
+  //   );
+  //   assert_eq!(execution_result.gas_left, 1000);
+  //   assert_eq!(execution_result.status_code, StatusCode::Success);
+  // }
+
+  #[test]
+  fn test_mock_vm() {
+    // construct a mock host
+    let host = MockHost::new(None);
+    let host_provider = HostProvider::new(host);
+    let host_interface = Arc::new(RefCell::new(host_provider));
 
     // construct a mock vm
     let vm = MockVm::new();
-    let host_interface = Arc::new(RefCell::new(host_provider));
 
     // test execution
     vm.execute(

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -54,7 +54,11 @@ where
     if let Some(input_data) = msg.input_data {
       stdin.write_vec(input_data);
     }
-    let output = self.client.execute(&code, stdin, Some(host)).unwrap();
+
+    let output = self
+      .client
+      .execute(&code, stdin, Some(host), msg.gas)
+      .unwrap();
     ExecutionResult::new(StatusCode::Success, 1337, Some(output.to_vec()), None)
   }
 }

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -55,11 +55,11 @@ where
       stdin.write_vec(input_data);
     }
 
-    let output = self
+    let (output, gas_left) = self
       .client
       .execute(&code, stdin, Some(host), msg.gas)
       .unwrap();
-    ExecutionResult::new(StatusCode::Success, 1337, Some(output.to_vec()), None)
+    ExecutionResult::new(StatusCode::Success, gas_left, Some(output.to_vec()), None)
   }
 }
 

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -57,9 +57,14 @@ where
 
     let (output, gas_left) = self
       .client
-      .execute(&code, stdin, Some(host), msg.gas)
+      .execute(&code, stdin, Some(host), Some(msg.gas))
       .unwrap();
-    ExecutionResult::new(StatusCode::Success, gas_left, Some(output.to_vec()), None)
+    ExecutionResult::new(
+      StatusCode::Success,
+      gas_left.unwrap(),
+      Some(output.to_vec()),
+      None,
+    )
   }
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -64,15 +64,16 @@ impl ExecutionClient {
     stdin: AthenaStdin,
     host: Option<Arc<RefCell<HostProvider<T>>>>,
     max_gas: u32,
-  ) -> Result<AthenaPublicValues> {
+  ) -> Result<(AthenaPublicValues, u32)> {
     let program = Program::from(elf);
     let opts =
       AthenaCoreOpts::default().with_options(vec![athena_core::utils::with_max_gas(max_gas)]);
     let mut runtime = Runtime::new(program, host, opts);
     runtime.write_vecs(&stdin.buffer);
-    runtime.run()?;
-    Ok(AthenaPublicValues::from(
-      &runtime.state.public_values_stream,
+    let gas_left = runtime.execute().unwrap();
+    Ok((
+      AthenaPublicValues::from(&runtime.state.public_values_stream),
+      gas_left,
     ))
   }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -86,8 +86,10 @@ impl Default for ExecutionClient {
 
 #[cfg(test)]
 mod tests {
+  use std::{cell::RefCell, sync::Arc};
+
   use crate::{utils, AthenaStdin, ExecutionClient};
-  use athena_interface::MockHost;
+  use athena_interface::{HostProvider, MockHost};
 
   #[test]
   fn test_execute() {
@@ -96,6 +98,28 @@ mod tests {
     let elf = include_bytes!("../../examples/fibonacci/program/elf/fibonacci-program");
     let mut stdin = AthenaStdin::new();
     stdin.write(&10usize);
+    client.execute::<MockHost>(elf, stdin, None, 0).unwrap();
+  }
+
+  #[test]
+  fn test_host() {
+    utils::setup_logger();
+    let client = ExecutionClient::new();
+    let elf = include_bytes!("../../tests/host/elf/host-test");
+    let stdin = AthenaStdin::new();
+    let host = Arc::new(RefCell::new(HostProvider::new(MockHost::new())));
+    client
+      .execute::<MockHost>(elf, stdin, Some(host), 0)
+      .unwrap();
+  }
+
+  #[test]
+  #[should_panic]
+  fn test_missing_host() {
+    utils::setup_logger();
+    let client = ExecutionClient::new();
+    let elf = include_bytes!("../../tests/host/elf/host-test");
+    let stdin = AthenaStdin::new();
     client.execute::<MockHost>(elf, stdin, None, 0).unwrap();
   }
 


### PR DESCRIPTION
Closes #4

It's dead simple. We just use the program clock as our gas meter; each instruction consumes 4 gas units. We can add more sophisticated gas metering in the future, including more sophisticated metering of the host functions. The basic infrastructure is in place.

Also doesn't contain many tests.