### PR TITLE
E2E FFI recursive host test

### DIFF
--- a/ffi/athcon/bindings/rust/athcon-client/src/lib.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/src/lib.rs
@@ -9,6 +9,9 @@ extern "C" {
   fn athcon_create_athenavmwrapper() -> *mut ffi::athcon_vm;
 }
 
+// In principle it's safe to clone these handles, but the caller needs to be very careful to
+// ensure the memory is freed properly, isn't double-freed, etc.
+#[derive(Clone)]
 pub struct AthconVm {
   handle: *mut ffi::athcon_vm,
   host_interface: *mut ffi::athcon_host_interface,

--- a/ffi/ffitest/Cargo.toml
+++ b/ffi/ffitest/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 
 [dev-dependencies]
 athcon-client = { path = "../athcon/bindings/rust/athcon-client" }
+athena-interface = { path = "../../interface" }
 athcon-sys = { path = "../athcon/bindings/rust/athcon-sys" }
 athena-vmlib = { path = "../vmlib" }
 hex = "0.4"


### PR DESCRIPTION
Closes #48 

Adds a roundtrip, recursive FFI test which tests all data conversion. Fix a couple of nasty conversion bugs. Don't convert to FFI/C types/raw pointers where it isn't strictly required.