### PR TITLE
Automatically detect arch and feature

### DIFF
--- a/vm/entrypoint/src/lib.rs
+++ b/vm/entrypoint/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! entrypoint {
 #[cfg(target_os = "zkvm")]
 mod vm {
   use crate::syscalls::syscall_halt;
+  use cfg_if::cfg_if;
 
   use getrandom::{register_custom_getrandom, Error};
 
@@ -58,15 +59,14 @@ mod vm {
 
   static STACK_TOP: u32 = 0x0020_0400;
 
-  #[cfg(feature = "rv32e")]
-  core::arch::global_asm!(include_str!("memset-rv32e.s"));
-  #[cfg(feature = "rv32e")]
-  core::arch::global_asm!(include_str!("memcpy-rv32e.s"));
-  #[cfg(not(feature = "rv32e"))]
-  core::arch::global_asm!(include_str!("memset.s"));
-  #[cfg(not(feature = "rv32e"))]
-  core::arch::global_asm!(include_str!("memcpy.s"));
-
+  cfg_if! {
+    if #[cfg(all(target_arch = "riscv32", target_feature = "e"))] {
+      core::arch::global_asm!(include_str!("memset-rv32e.s"));
+      core::arch::global_asm!(include_str!("memcpy-rv32e.s"));
+      core::arch::global_asm!(include_str!("memset.s"));
+      core::arch::global_asm!(include_str!("memcpy.s"));
+    }
+  }
   core::arch::global_asm!(
       r#"
     .section .text._start;


### PR DESCRIPTION
I think we can remove the `rv32e` feature entirely and just auto-detect from the Rust target

Closes #17