### PR TITLE
remove deadcode from athcon-declare

### DIFF
--- a/ffi/athcon/bindings/rust/athcon-declare/src/lib.rs
+++ b/ffi/athcon/bindings/rust/athcon-declare/src/lib.rs
@@ -38,6 +38,7 @@ extern crate proc_macro;
 use heck::AsShoutySnakeCase;
 use heck::AsSnakeCase;
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
 use syn::parse_macro_input;
 use syn::spanned::Spanned;
@@ -49,69 +50,35 @@ use syn::LitInt;
 use syn::LitStr;
 use syn::NestedMeta;
 
-struct VMNameSet {
-  type_name: String,
-  name_allcaps: String,
-  name_lowercase: String,
-}
+struct VMName(String);
 
 struct VMMetaData {
   capabilities: u32,
-  // Not included in VMNameSet because it is parsed from the meta-item arguments.
+  // Not included in VMName because it is parsed from the meta-item arguments.
   name_stylized: String,
   custom_version: String,
 }
 
-#[allow(dead_code)]
-impl VMNameSet {
+impl VMName {
   fn new(ident: String) -> Self {
-    let caps = format!("{}", AsShoutySnakeCase(ident.clone()));
-    let lowercase = format!("{}", AsSnakeCase(ident.clone()));
-    let lowercase = lowercase.chars().filter(|c| *c != '_').collect();
-    VMNameSet {
-      type_name: ident,
-      name_allcaps: caps,
-      name_lowercase: lowercase,
-    }
-  }
-
-  /// Return a reference to the struct name, as a string.
-  fn get_type_name(&self) -> &String {
-    &self.type_name
-  }
-
-  /// Return a reference to the name in shouty snake case.
-  fn get_name_caps(&self) -> &String {
-    &self.name_allcaps
-  }
-
-  /// Return a reference to the name in lowercase, with all underscores removed. (Used for
-  /// symbols like athcon_create_vmname)
-  fn get_name_lowercase(&self) -> &String {
-    &self.name_lowercase
+    VMName(ident)
   }
 
   /// Get the struct's name as an explicit identifier to be interpolated with quote.
-  fn get_type_as_ident(&self) -> Ident {
-    Ident::new(&self.type_name, self.type_name.span())
-  }
-
-  /// Get the lowercase name appended with arbitrary text as an explicit ident.
-  fn get_lowercase_as_ident_append(&self, suffix: &str) -> Ident {
-    let concat = format!("{}{}", &self.name_lowercase, suffix);
-    Ident::new(&concat, self.name_lowercase.span())
+  fn as_type_ident(&self) -> Ident {
+    Ident::new(&self.0, Span::call_site())
   }
 
   /// Get the lowercase name prepended with arbitrary text as an explicit ident.
   fn get_lowercase_as_ident_prepend(&self, prefix: &str) -> Ident {
-    let concat = format!("{}{}", prefix, &self.name_lowercase);
-    Ident::new(&concat, self.name_lowercase.span())
+    let concat = format!("{}{}", prefix, self.0.to_lowercase());
+    Ident::new(&concat, Span::call_site())
   }
 
   /// Get the lowercase name appended with arbitrary text as an explicit ident.
   fn get_caps_as_ident_append(&self, suffix: &str) -> Ident {
-    let concat = format!("{}{}", &self.name_allcaps, suffix);
-    Ident::new(&concat, self.name_allcaps.span())
+    let concat = format!("{}{}", AsShoutySnakeCase(&self.0), suffix);
+    Ident::new(&concat, Span::call_site())
   }
 }
 
@@ -216,20 +183,19 @@ pub fn athcon_declare_vm(args: TokenStream, item: TokenStream) -> TokenStream {
   // Extract the identifier of the struct from the AST node.
   let vm_type_name: String = input.ident.to_string();
 
-  // Build the VM name set.
-  let names = VMNameSet::new(vm_type_name);
+  let name = VMName::new(vm_type_name);
 
   // Parse the arguments for the macro.
   let meta_args = parse_macro_input!(args as AttributeArgs);
   let vm_data = VMMetaData::new(meta_args);
 
   // Get all the tokens from the respective helpers.
-  let static_data_tokens = build_static_data(&names, &vm_data);
+  let static_data_tokens = build_static_data(&name, &vm_data);
   let capabilities_tokens = build_capabilities_fn(vm_data.get_capabilities());
-  let set_option_tokens = build_set_option_fn(&names);
-  let create_tokens = build_create_fn(&names);
-  let destroy_tokens = build_destroy_fn(&names);
-  let execute_tokens = build_execute_fn(&names);
+  let set_option_tokens = build_set_option_fn(&name);
+  let create_tokens = build_create_fn(&name);
+  let destroy_tokens = build_destroy_fn(&name);
+  let execute_tokens = build_execute_fn(&name);
 
   let quoted = quote! {
       #input
@@ -245,10 +211,10 @@ pub fn athcon_declare_vm(args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Generate tokens for the static data associated with an athcon VM.
-fn build_static_data(names: &VMNameSet, metadata: &VMMetaData) -> proc_macro2::TokenStream {
+fn build_static_data(name: &VMName, metadata: &VMMetaData) -> proc_macro2::TokenStream {
   // Stitch together the VM name and the suffix _NAME
-  let static_name_ident = names.get_caps_as_ident_append("_NAME");
-  let static_version_ident = names.get_caps_as_ident_append("_VERSION");
+  let static_name_ident = name.get_caps_as_ident_append("_NAME");
+  let static_version_ident = name.get_caps_as_ident_append("_VERSION");
 
   // Turn the stylized VM name and version into string literals.
   let stylized_name_literal = LitStr::new(
@@ -278,8 +244,8 @@ fn build_capabilities_fn(capabilities: u32) -> proc_macro2::TokenStream {
   }
 }
 
-fn build_set_option_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
-  let type_name_ident = names.get_type_as_ident();
+fn build_set_option_fn(name: &VMName) -> proc_macro2::TokenStream {
+  let type_name_ident = name.as_type_ident();
 
   quote! {
       extern "C" fn __athcon_set_option(
@@ -336,12 +302,12 @@ fn build_set_option_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
 }
 
 /// Takes an identifier and struct definition, builds an athcon_create_* function for FFI.
-fn build_create_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
-  let type_ident = names.get_type_as_ident();
-  let fn_ident = names.get_lowercase_as_ident_prepend("athcon_create_");
+fn build_create_fn(name: &VMName) -> proc_macro2::TokenStream {
+  let type_ident = name.as_type_ident();
+  let fn_ident = name.get_lowercase_as_ident_prepend("athcon_create_");
 
-  let static_version_ident = names.get_caps_as_ident_append("_VERSION");
-  let static_name_ident = names.get_caps_as_ident_append("_NAME");
+  let static_version_ident = name.get_caps_as_ident_append("_VERSION");
+  let static_name_ident = name.get_caps_as_ident_append("_NAME");
 
   // Note: we can get CStrs unchecked because we did the checks on instantiation of VMMetaData.
   quote! {
@@ -368,8 +334,8 @@ fn build_create_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
 }
 
 /// Builds a callback to dispose of the VM instance.
-fn build_destroy_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
-  let type_ident = names.get_type_as_ident();
+fn build_destroy_fn(name: &VMName) -> proc_macro2::TokenStream {
+  let type_ident = name.as_type_ident();
 
   quote! {
       extern "C" fn __athcon_destroy(instance: *mut ::athcon_vm::ffi::athcon_vm) {
@@ -386,8 +352,8 @@ fn build_destroy_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
 }
 
 /// Builds the main execution entry point.
-fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
-  let type_name_ident = names.get_type_as_ident();
+fn build_execute_fn(name: &VMName) -> proc_macro2::TokenStream {
+  let type_name_ident = name.as_type_ident();
 
   quote! {
       extern "C" fn __athcon_execute(
@@ -448,5 +414,21 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
 
           result.into()
       }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn test_vm_name_prepend_lowercase() {
+    let name = super::VMName::new("ExampleVM".to_string());
+    let ident = name.get_lowercase_as_ident_prepend("athcon_");
+    assert_eq!(ident.to_string(), "athcon_examplevm");
+  }
+  #[test]
+  fn test_vm_name_append_caps() {
+    let name = super::VMName::new("ExampleVM".to_string());
+    let ident = name.get_caps_as_ident_append("_NAME");
+    assert_eq!(ident.to_string(), "EXAMPLE_VM_NAME");
   }
 }

--- a/ffi/athcon/bindings/rust/athcon-declare/src/lib.rs
+++ b/ffi/athcon/bindings/rust/athcon-declare/src/lib.rs
@@ -36,7 +36,6 @@
 extern crate proc_macro;
 
 use heck::AsShoutySnakeCase;
-use heck::AsSnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;


### PR DESCRIPTION
Removed `#[allow(dead_code)]` from the `athcon-declare` and cleaned up the code.