### PR TITLE
go bindings: refactors around `VM::Execute`

### DIFF
--- a/ffi/athcon/bindings/go/athcon.go
+++ b/ffi/athcon/bindings/go/athcon.go
@@ -187,6 +187,10 @@ func (vm *VM) Execute(
 		value:     athconBytes32(value),
 	}
 	if len(input) > 0 {
+		// Allocate memory for input data in C.
+		// Otherwise, the Go garbage collector may move the data around and
+		// invalidate the pointer passed to the C code.
+		// Without this, the CGO complains `cgo argument has Go pointer to unpinned Go pointer`.
 		cInputData := C.malloc(C.size_t(len(input)))
 		if cInputData == nil {
 			return res, fmt.Errorf("failed to allocate memory for input data")

--- a/ffi/athcon/bindings/go/host.go
+++ b/ffi/athcon/bindings/go/host.go
@@ -7,7 +7,10 @@ package athcon
 #include <athcon/helpers.h>
 */
 import "C"
-import "unsafe"
+import (
+	"runtime/cgo"
+	"unsafe"
+)
 
 type CallKind int
 
@@ -76,32 +79,31 @@ type HostContext interface {
 
 //export accountExists
 func accountExists(pCtx unsafe.Pointer, pAddr *C.athcon_address) C.bool {
-	ctx := getHostContext(uintptr(pCtx))
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 	return C.bool(ctx.AccountExists(goAddress(*pAddr)))
 }
 
 //export getStorage
 func getStorage(pCtx unsafe.Pointer, pAddr *C.struct_athcon_address, pKey *C.athcon_bytes32) C.athcon_bytes32 {
-	ctx := getHostContext(uintptr(pCtx))
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 	return athconBytes32(ctx.GetStorage(goAddress(*pAddr), goHash(*pKey)))
 }
 
 //export setStorage
 func setStorage(pCtx unsafe.Pointer, pAddr *C.athcon_address, pKey *C.athcon_bytes32, pVal *C.athcon_bytes32) C.enum_athcon_storage_status {
-	ctx := getHostContext(uintptr(pCtx))
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 	return C.enum_athcon_storage_status(ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal)))
 }
 
 //export getBalance
 func getBalance(pCtx unsafe.Pointer, pAddr *C.athcon_address) C.athcon_uint256be {
-	ctx := getHostContext(uintptr(pCtx))
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 	return athconBytes32(ctx.GetBalance(goAddress(*pAddr)))
 }
 
 //export getTxContext
 func getTxContext(pCtx unsafe.Pointer) C.struct_athcon_tx_context {
-	ctx := getHostContext(uintptr(pCtx))
-
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 	txContext := ctx.GetTxContext()
 
 	return C.struct_athcon_tx_context{
@@ -116,13 +118,13 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_athcon_tx_context {
 
 //export getBlockHash
 func getBlockHash(pCtx unsafe.Pointer, number int64) C.athcon_bytes32 {
-	ctx := getHostContext(uintptr(pCtx))
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 	return athconBytes32(ctx.GetBlockHash(number))
 }
 
 //export call
 func call(pCtx unsafe.Pointer, msg *C.struct_athcon_message) C.struct_athcon_result {
-	ctx := getHostContext(uintptr(pCtx))
+	ctx := cgo.Handle(pCtx).Value().(HostContext)
 
 	kind := CallKind(msg.kind)
 	output, gasLeft, createAddr, err := ctx.Call(kind, goAddress(msg.recipient), goAddress(msg.sender), goHash(msg.value),


### PR DESCRIPTION
Two notable changes around the `VM::Execute` method.

- use `cgo.Handle` for passing handle to the host context instead of using a global map
- removed the extra wrapper for calling `athcon_execute`. 