### PR TITLE
Fix toolchain build

### DIFF
--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -140,8 +140,6 @@ impl BuildToolchainCmd {
         "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
       .env("COMPILER_RT_DEFAULT_TARGET_TRIPLE", "riscv32-unknown-elf")
-      .env("CC_riscv32em_athena_zkvm_elf", "clang")
-      .env("CXX_riscv32em_athena_zkvm_elf", "clang++")
       .env("RUSTC_TARGET_ARG", "")
       .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build"])
@@ -159,8 +157,6 @@ impl BuildToolchainCmd {
         "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
       .env("COMPILER_RT_DEFAULT_TARGET_TRIPLE", "riscv32-unknown-elf")
-      .env("CC_riscv32em_athena_zkvm_elf", "clang")
-      .env("CXX_riscv32em_athena_zkvm_elf", "clang++")
       .env("RUSTC_TARGET_ARG", "")
       .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build", "--stage", "2"])

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -129,8 +129,11 @@ impl BuildToolchainCmd {
       .output()
       .expect("Failed to run patch command");
     if !patch_output.status.success() {
+      let stdout = str::from_utf8(&patch_output.stdout).unwrap_or("Failed to read stdout");
       let stderr = str::from_utf8(&patch_output.stderr).unwrap_or("Failed to read stderr");
-      println!("Failed to apply patches to rust with code: {:?}. This is expected if the patches have already been applied. Error output: {}", patch_output.status.code(), stderr);
+      println!("Failed to apply patches to rust with code: {:?}. This is expected if the patches have already been applied.", patch_output.status.code());
+      println!("stdout: {}", stdout);
+      println!("stderr: {}", stderr);
     }
 
     // Create the custom target file.

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -150,10 +150,6 @@ impl BuildToolchainCmd {
         "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
       )
       .env(
-        "CXXFLAGS_riscv32em_athena_zkvm_elf",
-        "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
-      )
-      .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
         "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
@@ -170,10 +166,6 @@ impl BuildToolchainCmd {
     Command::new("python3")
       .env(
         "CFLAGS_riscv32em_athena_zkvm_elf",
-        "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
-      )
-      .env(
-        "CXXFLAGS_riscv32em_athena_zkvm_elf",
         "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
       )
       .env(

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -150,6 +150,10 @@ impl BuildToolchainCmd {
         "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
       )
       .env(
+        "CXXFLAGS_riscv32em_athena_zkvm_elf",
+        "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
+      )
+      .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
         "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
@@ -166,6 +170,10 @@ impl BuildToolchainCmd {
     Command::new("python3")
       .env(
         "CFLAGS_riscv32em_athena_zkvm_elf",
+        "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
+      )
+      .env(
+        "CXXFLAGS_riscv32em_athena_zkvm_elf",
         "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
       )
       .env(

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -126,8 +126,8 @@ impl BuildToolchainCmd {
         toolchain_dir.join("patches/rust.patch").to_str().unwrap(),
       ])
       .current_dir(&rust_dir)
-      .output()
-      .expect("Failed to run patch command");
+      .output()?;
+
     if !patch_output.status.success() {
       let stdout = str::from_utf8(&patch_output.stdout).unwrap_or("Failed to read stdout");
       let stderr = str::from_utf8(&patch_output.stderr).unwrap_or("Failed to read stderr");

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -161,7 +161,7 @@ impl BuildToolchainCmd {
         break;
       }
     }
-    let toolchain_dir = toolchain_dir.unwrap();
+    let toolchain_dir = toolchain_dir.expect("Missing Rust toolchain directory");
     println!(
       "Found built toolchain directory at {}.",
       toolchain_dir.as_path().to_str().unwrap()

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -151,6 +151,8 @@ impl BuildToolchainCmd {
         "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
       .env("COMPILER_RT_DEFAULT_TARGET_TRIPLE", "riscv32-unknown-elf")
+      .env("CC_riscv32em_athena_zkvm_elf", "clang")
+      .env("CXX_riscv32em_athena_zkvm_elf", "clang++")
       .env("RUSTC_TARGET_ARG", "")
       .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build"])
@@ -168,6 +170,8 @@ impl BuildToolchainCmd {
         "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
       .env("COMPILER_RT_DEFAULT_TARGET_TRIPLE", "riscv32-unknown-elf")
+      .env("CC_riscv32em_athena_zkvm_elf", "clang")
+      .env("CXX_riscv32em_athena_zkvm_elf", "clang++")
       .env("RUSTC_TARGET_ARG", "")
       .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build", "--stage", "2"])

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -137,8 +137,12 @@ impl BuildToolchainCmd {
       )
       .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
-        "-Cpasses=loweratomic",
+        "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
+      .env("COMPILER_RT_DEFAULT_TARGET_TRIPLE", "riscv32-unknown-elf")
+      .env("CC_riscv32em_athena_zkvm_elf", "clang")
+      .env("CXX_riscv32em_athena_zkvm_elf", "clang++")
+      .env("RUSTC_TARGET_ARG", "")
       .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build"])
       .current_dir(&rust_dir)
@@ -152,8 +156,12 @@ impl BuildToolchainCmd {
       )
       .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
-        "-Cpasses=loweratomic",
+        "-Cpasses=loweratomic -Clink-arg=-march=rv32em -Clink-arg=-mabi=ilp32e",
       )
+      .env("COMPILER_RT_DEFAULT_TARGET_TRIPLE", "riscv32-unknown-elf")
+      .env("CC_riscv32em_athena_zkvm_elf", "clang")
+      .env("CXX_riscv32em_athena_zkvm_elf", "clang++")
+      .env("RUSTC_TARGET_ARG", "")
       .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build", "--stage", "2"])
       .current_dir(&rust_dir)

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -132,6 +132,10 @@ impl BuildToolchainCmd {
     // Build the toolchain (stage 1).
     Command::new("python3")
       .env(
+        "CFLAGS_riscv32em_athena_zkvm_elf",
+        "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
+      )
+      .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
         "-Cpasses=loweratomic",
       )
@@ -142,6 +146,10 @@ impl BuildToolchainCmd {
 
     // Build the toolchain (stage 2).
     Command::new("python3")
+      .env(
+        "CFLAGS_riscv32em_athena_zkvm_elf",
+        "-ffunction-sections -fdata-sections -fPIC -target riscv32-unknown-elf",
+      )
       .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
         "-Cpasses=loweratomic",

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -122,12 +122,20 @@ impl BuildToolchainCmd {
       .current_dir(&rust_dir)
       .run()?;
 
+    // Create the custom target file.
+    // Note: Rust doesn't actually read this file, it just needs to see that it exists
+    // to get past the bootstrap phase.
+    Command::new("touch")
+      .arg(toolchain_dir.join("riscv32em-athena-zkvm-elf.json"))
+      .run()?;
+
     // Build the toolchain (stage 1).
     Command::new("python3")
       .env(
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
         "-Cpasses=loweratomic",
       )
+      .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build"])
       .current_dir(&rust_dir)
       .run()?;
@@ -138,6 +146,7 @@ impl BuildToolchainCmd {
         "CARGO_TARGET_RISCV32EM_ATHENA_ZKVM_ELF_RUSTFLAGS",
         "-Cpasses=loweratomic",
       )
+      .env("RUST_TARGET_PATH", &toolchain_dir)
       .args(["x.py", "build", "--stage", "2"])
       .current_dir(&rust_dir)
       .run()?;

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -61,11 +61,14 @@ impl BuildToolchainCmd {
         "https://github.com/rust-lang/rust.git".to_string()
       }
     };
-    Command::new("git")
-      .args(["clone", &rust_repo_url, "--depth=1"])
-      .current_dir(&toolchain_dir)
-      .run()?;
+
     let rust_dir = toolchain_dir.join("rust");
+    if !rust_dir.exists() {
+      Command::new("git")
+        .args(["clone", &rust_repo_url, "--depth=1"])
+        .current_dir(&toolchain_dir)
+        .run()?;
+    }
 
     // Read the Rust commit hash
     let rust_commit = std::fs::read_to_string(toolchain_dir.join("rust_commit.txt"))?

--- a/cli/src/commands/build_toolchain.rs
+++ b/cli/src/commands/build_toolchain.rs
@@ -131,7 +131,7 @@ impl BuildToolchainCmd {
     if !patch_output.status.success() {
       let stdout = str::from_utf8(&patch_output.stdout).unwrap_or("Failed to read stdout");
       let stderr = str::from_utf8(&patch_output.stderr).unwrap_or("Failed to read stderr");
-      println!("Failed to apply patches to rust with code: {:?}. This is expected if the patches have already been applied.", patch_output.status.code());
+      println!("Failed to apply patches to rust with code: {:?}. This is expected if the patches have already been applied.", patch_output.status.code().unwrap());
       println!("stdout: {}", stdout);
       println!("stderr: {}", stderr);
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -28,7 +28,16 @@ impl CommandExecutor for Command {
       .stdin(Stdio::inherit())
       .output()
       .with_context(|| format!("while executing `{:?}`", &self))
-      .map(|_| ())
+      .and_then(|output| {
+        if output.status.success() {
+          Ok(())
+        } else {
+          Err(anyhow::anyhow!(
+            "Command failed with exit code: {}",
+            output.status
+          ))
+        }
+      })
   }
 }
 


### PR DESCRIPTION
Fix some small issues in the build toolchain CLI command

This brings over some logic from https://github.com/athenavm/rustc-rv32e-toolchain/pull/5 and https://github.com/athenavm/rustc-rv32e-toolchain/pull/8 to allow building Rust >= 1.80, which is unfortunately duplicative for now. Opened #93 to sort this out.