### PR TITLE
make Runtime hold mut reference to HostInterface

### DIFF
--- a/cli/src/commands/execute.rs
+++ b/cli/src/commands/execute.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 use athena_builder::{build_program, BuildArgs};
 use athena_core::io::AthenaStdin;
 use athena_core::utils::{setup_logger, setup_tracer};
-use athena_interface::MockHost;
 use athena_sdk::ExecutionClient;
 use clap::Parser;
 use std::time::Instant;
@@ -111,9 +110,7 @@ impl ExecuteCmd {
     let start_time = Instant::now();
     let client = ExecutionClient::new();
     // no host interface needed for direct execution
-    let (output, _gas_left) = client
-      .execute::<MockHost>(&elf, stdin, None, None, None)
-      .unwrap();
+    let (output, _gas_left) = client.execute(&elf, stdin, None, None, None).unwrap();
 
     let elapsed = elapsed(start_time.elapsed());
     let green = AnsiColor::Green.on_default().effects(Effects::BOLD);

--- a/core/src/runtime/io.rs
+++ b/core/src/runtime/io.rs
@@ -1,25 +1,18 @@
 use std::io::Read;
 
-use athena_interface::HostInterface;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use super::Runtime;
 
-impl<'host, T> Read for Runtime<'host, T>
-where
-  T: HostInterface,
-{
+impl<'host> Read for Runtime<'host> {
   fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
     self.read_public_values_slice(buf);
     Ok(buf.len())
   }
 }
 
-impl<'host, T> Runtime<'host, T>
-where
-  T: HostInterface,
-{
+impl<'host> Runtime<'host> {
   pub fn write_stdin<U: Serialize>(&mut self, input: &U) {
     let mut buf = Vec::new();
     bincode::serialize_into(&mut buf, input).expect("serialization failed");
@@ -56,7 +49,6 @@ pub mod tests {
   use super::*;
   use crate::runtime::Program;
   use crate::utils::{setup_logger, tests::IO_ELF, AthenaCoreOpts};
-  use athena_interface::MockHost;
   use serde::Deserialize;
 
   #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -85,7 +77,7 @@ pub mod tests {
   fn test_io_run() {
     setup_logger();
     let program = Program::from(IO_ELF);
-    let mut runtime = Runtime::<MockHost>::new(program, None, AthenaCoreOpts::default(), None);
+    let mut runtime = Runtime::new(program, None, AthenaCoreOpts::default(), None);
     let points = points();
     runtime.write_stdin(&points.0);
     runtime.write_stdin(&points.1);

--- a/core/src/runtime/io.rs
+++ b/core/src/runtime/io.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use super::Runtime;
 
-impl<T> Read for Runtime<T>
+impl<'host, T> Read for Runtime<'host, T>
 where
   T: HostInterface,
 {
@@ -16,7 +16,7 @@ where
   }
 }
 
-impl<T> Runtime<T>
+impl<'host, T> Runtime<'host, T>
 where
   T: HostInterface,
 {

--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -85,20 +85,20 @@ pub trait Syscall<T: HostInterface>: Send + Sync {
 }
 
 /// A runtime for syscalls that is protected so that developers cannot arbitrarily modify the runtime.
-pub struct SyscallContext<'a, T: HostInterface> {
+pub struct SyscallContext<'a, 'h, T: HostInterface> {
   pub clk: u32,
 
   pub(crate) next_pc: u32,
   /// This is the exit_code used for the HALT syscall
   pub(crate) exit_code: u32,
-  pub(crate) rt: &'a mut Runtime<T>,
+  pub(crate) rt: &'a mut Runtime<'h, T>,
 }
 
-impl<'a, T> SyscallContext<'a, T>
+impl<'a, 'h, T> SyscallContext<'a, 'h, T>
 where
   T: HostInterface,
 {
-  pub fn new(runtime: &'a mut Runtime<T>) -> Self {
+  pub fn new(runtime: &'a mut Runtime<'h, T>) -> Self {
     let clk = runtime.state.clk;
     Self {
       clk,

--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -9,8 +9,6 @@ use crate::syscall::{
   SyscallHostRead, SyscallHostWrite, SyscallWrite,
 };
 
-use athena_interface::HostInterface;
-
 /// A system call is invoked by the the `ecall` instruction with a specific value in register t0.
 /// The syscall number is a 32-bit integer, with the following layout (in little-endian format)
 /// - The first byte is the syscall id.
@@ -69,13 +67,13 @@ impl SyscallCode {
   }
 }
 
-pub trait Syscall<T: HostInterface>: Send + Sync {
+pub trait Syscall: Send + Sync {
   /// Execute the syscall and return the resulting value of register a0. `arg1` and `arg2` are the
   /// values in registers X10 and X11, respectively. While not a hard requirement, the convention
   /// is that the return value is only for system calls such as `HALT`. Most precompiles use `arg1`
   /// and `arg2` to denote the addresses of the input data, and write the result to the memory at
   /// `arg1`.
-  fn execute(&self, ctx: &mut SyscallContext<T>, arg1: u32, arg2: u32) -> Option<u32>;
+  fn execute(&self, ctx: &mut SyscallContext, arg1: u32, arg2: u32) -> Option<u32>;
 
   /// The number of extra cycles that the syscall takes to execute. Unless this syscall is complex
   /// and requires many cycles, this should be zero.
@@ -85,20 +83,17 @@ pub trait Syscall<T: HostInterface>: Send + Sync {
 }
 
 /// A runtime for syscalls that is protected so that developers cannot arbitrarily modify the runtime.
-pub struct SyscallContext<'a, 'h, T: HostInterface> {
+pub struct SyscallContext<'a, 'h> {
   pub clk: u32,
 
   pub(crate) next_pc: u32,
   /// This is the exit_code used for the HALT syscall
   pub(crate) exit_code: u32,
-  pub(crate) rt: &'a mut Runtime<'h, T>,
+  pub(crate) rt: &'a mut Runtime<'h>,
 }
 
-impl<'a, 'h, T> SyscallContext<'a, 'h, T>
-where
-  T: HostInterface,
-{
-  pub fn new(runtime: &'a mut Runtime<'h, T>) -> Self {
+impl<'a, 'h> SyscallContext<'a, 'h> {
+  pub fn new(runtime: &'a mut Runtime<'h>) -> Self {
     let clk = runtime.state.clk;
     Self {
       clk,
@@ -147,8 +142,8 @@ where
   }
 }
 
-pub fn default_syscall_map<T: HostInterface>() -> HashMap<SyscallCode, Arc<dyn Syscall<T>>> {
-  let mut syscall_map = HashMap::<SyscallCode, Arc<dyn Syscall<T>>>::default();
+pub fn default_syscall_map() -> HashMap<SyscallCode, Arc<dyn Syscall>> {
+  let mut syscall_map = HashMap::<SyscallCode, Arc<dyn Syscall>>::default();
   syscall_map.insert(SyscallCode::HALT, Arc::new(SyscallHalt {}));
   syscall_map.insert(SyscallCode::WRITE, Arc::new(SyscallWrite::new()));
   syscall_map.insert(SyscallCode::HOST_READ, Arc::new(SyscallHostRead::new()));
@@ -167,12 +162,11 @@ pub fn default_syscall_map<T: HostInterface>() -> HashMap<SyscallCode, Arc<dyn S
 #[cfg(test)]
 mod tests {
   use super::{default_syscall_map, SyscallCode};
-  use athena_interface::MockHost;
   use strum::IntoEnumIterator;
 
   #[test]
   fn test_syscalls_in_default_map() {
-    let default_syscall_map = default_syscall_map::<MockHost>();
+    let default_syscall_map = default_syscall_map();
     for code in SyscallCode::iter() {
       default_syscall_map.get(&code).unwrap();
     }
@@ -180,7 +174,7 @@ mod tests {
 
   #[test]
   fn test_syscall_num_cycles_encoding() {
-    for (syscall_code, syscall_impl) in default_syscall_map::<MockHost>().iter() {
+    for (syscall_code, syscall_impl) in default_syscall_map().iter() {
       let encoded_num_cycles = syscall_code.num_cycles();
       assert_eq!(syscall_impl.num_extra_cycles(), encoded_num_cycles);
     }
@@ -188,7 +182,7 @@ mod tests {
 
   #[test]
   fn test_encoding_roundtrip() {
-    for (syscall_code, _) in default_syscall_map::<MockHost>().iter() {
+    for (syscall_code, _) in default_syscall_map().iter() {
       assert_eq!(SyscallCode::from_u32(*syscall_code as u32), *syscall_code);
     }
   }

--- a/core/src/runtime/utils.rs
+++ b/core/src/runtime/utils.rs
@@ -9,7 +9,7 @@ pub const fn align(addr: u32) -> u32 {
   addr - addr % 4
 }
 
-impl<T> Runtime<T>
+impl<'h, T> Runtime<'h, T>
 where
   T: HostInterface,
 {

--- a/core/src/runtime/utils.rs
+++ b/core/src/runtime/utils.rs
@@ -1,7 +1,5 @@
 use std::io::Write;
 
-use athena_interface::HostInterface;
-
 use super::{Instruction, Runtime};
 use crate::runtime::Register;
 
@@ -9,10 +7,7 @@ pub const fn align(addr: u32) -> u32 {
   addr - addr % 4
 }
 
-impl<'h, T> Runtime<'h, T>
-where
-  T: HostInterface,
-{
+impl<'h> Runtime<'h> {
   #[inline]
   pub fn log(&mut self, instruction: &Instruction) {
     // Write the current program counter to the trace buffer for the cycle tracer.

--- a/core/src/syscall/halt.rs
+++ b/core/src/syscall/halt.rs
@@ -1,5 +1,4 @@
 use crate::runtime::{Syscall, SyscallContext};
-use athena_interface::HostInterface;
 
 pub struct SyscallHalt;
 
@@ -9,11 +8,8 @@ impl SyscallHalt {
   }
 }
 
-impl<T> Syscall<T> for SyscallHalt
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, exit_code: u32, _: u32) -> Option<u32> {
+impl Syscall for SyscallHalt {
+  fn execute(&self, ctx: &mut SyscallContext, exit_code: u32, _: u32) -> Option<u32> {
     log::info!("Halt syscall with exit code {}", exit_code);
     ctx.set_next_pc(0);
     ctx.set_exit_code(exit_code);

--- a/core/src/syscall/hint.rs
+++ b/core/src/syscall/hint.rs
@@ -1,5 +1,3 @@
-use athena_interface::HostInterface;
-
 use crate::runtime::{Syscall, SyscallContext};
 
 pub struct SyscallHintLen;
@@ -11,11 +9,8 @@ impl SyscallHintLen {
   }
 }
 
-impl<T> Syscall<T> for SyscallHintLen
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, _arg1: u32, _arg2: u32) -> Option<u32> {
+impl Syscall for SyscallHintLen {
+  fn execute(&self, ctx: &mut SyscallContext, _arg1: u32, _arg2: u32) -> Option<u32> {
     if ctx.rt.state.input_stream_ptr >= ctx.rt.state.input_stream.len() {
       panic!(
              "failed reading stdin due to insufficient input data: input_stream_ptr={}, input_stream_len={}",
@@ -36,11 +31,8 @@ impl SyscallHintRead {
   }
 }
 
-impl<T> Syscall<T> for SyscallHintRead
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, ptr: u32, len: u32) -> Option<u32> {
+impl Syscall for SyscallHintRead {
+  fn execute(&self, ctx: &mut SyscallContext, ptr: u32, len: u32) -> Option<u32> {
     if ctx.rt.state.input_stream_ptr >= ctx.rt.state.input_stream.len() {
       panic!(
              "failed reading stdin due to insufficient input data: input_stream_ptr={}, input_stream_len={}",

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -28,9 +28,7 @@ where
 
     // read value from host
     let host = ctx.rt.host.as_mut().expect("Missing host interface");
-    let value = host
-      .borrow()
-      .get_storage(athena_ctx.address(), &Bytes32Wrapper::from(key).into());
+    let value = host.get_storage(athena_ctx.address(), &Bytes32Wrapper::from(key).into());
 
     // set return value
     let value_vec: Vec<u32> = Bytes32Wrapper::new(value).into();
@@ -63,8 +61,8 @@ where
     let value = ctx.slice(arg2, BYTES32_LENGTH / 4);
 
     // write value to host
-    let host = ctx.rt.host.as_mut().expect("Missing host interface");
-    let status_code = host.borrow_mut().set_storage(
+    let host = ctx.rt.host.as_deref_mut().expect("Missing host interface");
+    let status_code = host.set_storage(
       athena_ctx.address(),
       &Bytes32Wrapper::from(key).into(),
       &Bytes32Wrapper::from(value).into(),
@@ -97,12 +95,6 @@ where
       .context
       .as_ref()
       .expect("Missing Athena runtime context");
-    let mut host = ctx
-      .rt
-      .host
-      .as_ref()
-      .expect("Missing host interface")
-      .borrow_mut();
 
     // get remaining gas
     // note: this does not factor in the cost of the current instruction
@@ -160,7 +152,12 @@ where
       amount,
       Vec::new(),
     );
-    let res = host.call(msg);
+    let res = ctx
+      .rt
+      .host
+      .as_deref_mut()
+      .expect("Missing host interface")
+      .call(msg);
 
     // calculate gas spent
     // TODO: should this be a panic or should it just return an out of gas error?
@@ -194,8 +191,8 @@ where
       .expect("Missing Athena runtime context");
 
     // get value from host
-    let host = ctx.rt.host.as_mut().expect("Missing host interface");
-    let balance = host.borrow_mut().get_balance(athena_ctx.address());
+    let host = ctx.rt.host.as_deref_mut().expect("Missing host interface");
+    let balance = host.get_balance(athena_ctx.address());
     let balance_high = (balance >> 32) as u32;
     let balance_low = balance as u32;
     let balance_slice = [balance_low, balance_high];

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -1,7 +1,6 @@
 use crate::runtime::{Register, Syscall, SyscallContext};
 use athena_interface::{
-  AddressWrapper, AthenaMessage, Bytes32Wrapper, HostInterface, MessageKind, ADDRESS_LENGTH,
-  BYTES32_LENGTH,
+  AddressWrapper, AthenaMessage, Bytes32Wrapper, MessageKind, ADDRESS_LENGTH, BYTES32_LENGTH,
 };
 
 pub struct SyscallHostRead;
@@ -12,11 +11,8 @@ impl SyscallHostRead {
   }
 }
 
-impl<T> Syscall<T> for SyscallHostRead
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, arg1: u32, _arg2: u32) -> Option<u32> {
+impl Syscall for SyscallHostRead {
+  fn execute(&self, ctx: &mut SyscallContext, arg1: u32, _arg2: u32) -> Option<u32> {
     let athena_ctx = ctx
       .rt
       .context
@@ -45,11 +41,8 @@ impl SyscallHostWrite {
   }
 }
 
-impl<T> Syscall<T> for SyscallHostWrite
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, arg1: u32, arg2: u32) -> Option<u32> {
+impl Syscall for SyscallHostWrite {
+  fn execute(&self, ctx: &mut SyscallContext, arg1: u32, arg2: u32) -> Option<u32> {
     let athena_ctx = ctx
       .rt
       .context
@@ -84,11 +77,8 @@ impl SyscallHostCall {
   }
 }
 
-impl<T> Syscall<T> for SyscallHostCall
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, arg1: u32, arg2: u32) -> Option<u32> {
+impl Syscall for SyscallHostCall {
+  fn execute(&self, ctx: &mut SyscallContext, arg1: u32, arg2: u32) -> Option<u32> {
     // make sure we have a runtime context
     let athena_ctx = ctx
       .rt
@@ -179,11 +169,8 @@ impl SyscallHostGetBalance {
   }
 }
 
-impl<T> Syscall<T> for SyscallHostGetBalance
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, arg1: u32, _arg2: u32) -> Option<u32> {
+impl Syscall for SyscallHostGetBalance {
+  fn execute(&self, ctx: &mut SyscallContext, arg1: u32, _arg2: u32) -> Option<u32> {
     let athena_ctx = ctx
       .rt
       .context

--- a/core/src/syscall/write.rs
+++ b/core/src/syscall/write.rs
@@ -1,5 +1,3 @@
-use athena_interface::HostInterface;
-
 use crate::{
   runtime::{Register, Syscall, SyscallContext},
   utils::num_to_comma_separated,
@@ -13,11 +11,8 @@ impl SyscallWrite {
   }
 }
 
-impl<T> Syscall<T> for SyscallWrite
-where
-  T: HostInterface,
-{
-  fn execute(&self, ctx: &mut SyscallContext<T>, arg1: u32, arg2: u32) -> Option<u32> {
+impl Syscall for SyscallWrite {
+  fn execute(&self, ctx: &mut SyscallContext, arg1: u32, arg2: u32) -> Option<u32> {
     let a2 = Register::X12;
     let rt = &mut ctx.rt;
     let fd = arg1;
@@ -86,11 +81,7 @@ where
   }
 }
 
-pub fn update_io_buf<T: HostInterface>(
-  ctx: &mut SyscallContext<T>,
-  fd: u32,
-  s: &str,
-) -> Vec<String> {
+pub fn update_io_buf(ctx: &mut SyscallContext, fd: u32, s: &str) -> Vec<String> {
   let rt = &mut ctx.rt;
   let entry = rt.io_buf.entry(fd).or_default();
   entry.push_str(s);

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, panic, sync::Arc};
+use std::panic;
 
 use athcon_declare::athcon_declare_vm;
 use athcon_sys as ffi;
@@ -55,15 +55,13 @@ impl AthconVm for AthenaVMWrapper {
     // Unpack the context
     let host_interface: &ffi::athcon_host_interface = unsafe { &*host };
     let execution_context = AthconExecutionContext::new(host_interface, context);
-    let host = WrappedHostInterface::new(execution_context);
-    #[allow(clippy::arc_with_non_send_sync)]
-    let host = Arc::new(RefCell::new(host));
+    let mut host = WrappedHostInterface::new(execution_context);
 
     // Execute the code and proxy the result back to the caller
     let execution_result =
       self
         .athena_vm
-        .execute(host, RevisionWrapper::from(rev).0, athena_msg.0, code);
+        .execute(&mut host, RevisionWrapper::from(rev).0, athena_msg.0, code);
     ExecutionResultWrapper(execution_result).into()
   }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -5,7 +5,7 @@
 mod context;
 pub use context::*;
 
-use std::{cell::RefCell, collections::BTreeMap, convert::TryFrom, fmt, sync::Arc};
+use std::{collections::BTreeMap, convert::TryFrom, fmt};
 
 pub const ADDRESS_LENGTH: usize = 24;
 pub const BYTES32_LENGTH: usize = 32;
@@ -456,21 +456,8 @@ impl<'a> HostInterface for MockHost<'a> {
       // create an owned copy of VM before taking the host from self
       let vm = self.vm;
 
-      // host requires an owned instance, so we need to take it from self
-      #[allow(clippy::arc_with_non_send_sync)]
-      let host = Arc::new(RefCell::new(std::mem::take(self)));
-      let res = vm.expect("missing VM instance").execute(
-        host.clone(),
-        AthenaRevision::AthenaFrontier,
-        msg,
-        code,
-      );
-
-      // Restore self
-      *self = Arc::try_unwrap(host)
-        .unwrap_or_else(|_| panic!("Arc still has multiple strong references"))
-        .into_inner();
-      res
+      vm.expect("missing VM instance")
+        .execute(self, AthenaRevision::AthenaFrontier, msg, code)
     } else {
       // otherwise, pass a call to Charlie, fail all other calls
       let status_code = if msg.recipient == ADDRESS_CHARLIE {
@@ -531,7 +518,7 @@ pub trait VmInterface<T: HostInterface> {
   fn set_option(&self, option: AthenaOption, value: &str) -> Result<(), SetOptionError>;
   fn execute(
     &self,
-    host: Arc<RefCell<T>>,
+    host: &mut T,
     rev: AthenaRevision,
     msg: AthenaMessage,
     code: &[u8],

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -129,7 +129,7 @@ mod tests {
       STORAGE_VALUE
     );
     let (mut output, _) = client
-      .execute::<MockHost>(
+      .execute(
         elf,
         stdin,
         Some(&mut host),
@@ -161,7 +161,7 @@ mod tests {
     host.deploy_code(ADDRESS_ALICE, elf);
     let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
     let (mut output, _) = client
-      .execute::<MockHost>(elf, stdin, Some(&mut host), Some(1000), Some(ctx.clone()))
+      .execute(elf, stdin, Some(&mut host), Some(1000), Some(ctx.clone()))
       .unwrap();
     let result = output.read::<Balance>();
     assert_eq!(result, SOME_COINS, "got wrong output value");
@@ -218,7 +218,7 @@ mod tests {
     let mut host = MockHost::new_with_vm(&vm);
     host.deploy_code(ADDRESS_ALICE, elf);
     let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
-    let res = client.execute::<MockHost>(elf, stdin, Some(&mut host), Some(1_000_000), Some(ctx));
+    let res = client.execute(elf, stdin, Some(&mut host), Some(1_000_000), Some(ctx));
     match res {
       Ok(_) => panic!("expected stack depth error"),
       Err(ExecutionError::HostCallFailed(StatusCode::CallDepthExceeded)) => (),

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -1,5 +1,3 @@
-use std::{cell::RefCell, sync::Arc};
-
 use athena_core::runtime::ExecutionError;
 use athena_interface::{
   AthenaCapability, AthenaContext, AthenaMessage, AthenaOption, AthenaRevision, ExecutionResult,
@@ -39,7 +37,7 @@ where
 
   fn execute(
     &self,
-    host: Arc<RefCell<T>>,
+    host: &mut T,
     _rev: AthenaRevision,
     msg: AthenaMessage,
     // note: ignore msg.code, should only be used on deploy
@@ -84,7 +82,6 @@ where
 
 #[cfg(test)]
 mod tests {
-  use std::{cell::RefCell, sync::Arc};
 
   use super::*;
   use athena_interface::{
@@ -96,12 +93,9 @@ mod tests {
   #[test]
   #[should_panic]
   fn test_empty_code() {
-    #[allow(clippy::arc_with_non_send_sync)]
-    let host_interface = Arc::new(RefCell::new(MockHost::new()));
-
     // construct a vm
     AthenaVm::new().execute(
-      host_interface,
+      &mut MockHost::new(),
       AthenaRevision::AthenaFrontier,
       AthenaMessage::new(
         MessageKind::Call,
@@ -127,19 +121,18 @@ mod tests {
     let mut stdin = AthenaStdin::new();
     stdin.write::<u32>(&7);
     let vm = AthenaVm::new();
-    #[allow(clippy::arc_with_non_send_sync)]
-    let host = Arc::new(RefCell::new(MockHost::new_with_vm(&vm)));
-    host.borrow_mut().deploy_code(ADDRESS_ALICE, elf);
+    let mut host = MockHost::new_with_vm(&vm);
+    host.deploy_code(ADDRESS_ALICE, elf);
     let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
     assert_eq!(
-      host.borrow().get_storage(&ADDRESS_ALICE, &STORAGE_KEY),
+      host.get_storage(&ADDRESS_ALICE, &STORAGE_KEY),
       STORAGE_VALUE
     );
     let (mut output, _) = client
       .execute::<MockHost>(
         elf,
         stdin,
-        Some(host.clone()),
+        Some(&mut host),
         Some(150_000),
         Some(ctx.clone()),
       )
@@ -149,7 +142,7 @@ mod tests {
 
     // expect storage value to also have been updated
     assert_eq!(
-      host.borrow().get_storage(&ADDRESS_ALICE, &STORAGE_KEY),
+      host.get_storage(&ADDRESS_ALICE, &STORAGE_KEY),
       [
         13u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0
@@ -164,18 +157,11 @@ mod tests {
     let elf = include_bytes!("../../tests/minimal/getbalance.bin");
     let stdin = AthenaStdin::new();
     let vm = AthenaVm::new();
-    #[allow(clippy::arc_with_non_send_sync)]
-    let host = Arc::new(RefCell::new(MockHost::new_with_vm(&vm)));
-    // host.borrow_mut().deploy_code(ADDRESS_ALICE, elf);
+    let mut host = MockHost::new_with_vm(&vm);
+    host.deploy_code(ADDRESS_ALICE, elf);
     let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
     let (mut output, _) = client
-      .execute::<MockHost>(
-        elf,
-        stdin,
-        Some(host.clone()),
-        Some(1000),
-        Some(ctx.clone()),
-      )
+      .execute::<MockHost>(elf, stdin, Some(&mut host), Some(1000), Some(ctx.clone()))
       .unwrap();
     let result = output.read::<Balance>();
     assert_eq!(result, SOME_COINS, "got wrong output value");
@@ -229,11 +215,10 @@ mod tests {
     let elf = include_bytes!("../../tests/stack_depth/elf/stack-depth-test");
     let stdin = AthenaStdin::new();
     let vm = AthenaVm::new();
-    #[allow(clippy::arc_with_non_send_sync)]
-    let host = Arc::new(RefCell::new(MockHost::new_with_vm(&vm)));
-    host.borrow_mut().deploy_code(ADDRESS_ALICE, elf);
+    let mut host = MockHost::new_with_vm(&vm);
+    host.deploy_code(ADDRESS_ALICE, elf);
     let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
-    let res = client.execute::<MockHost>(elf, stdin, Some(host), Some(1_000_000), Some(ctx));
+    let res = client.execute::<MockHost>(elf, stdin, Some(&mut host), Some(1_000_000), Some(ctx));
     match res {
       Ok(_) => panic!("expected stack depth error"),
       Err(ExecutionError::HostCallFailed(StatusCode::CallDepthExceeded)) => (),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -35,7 +35,6 @@ impl ExecutionClient {
   ///
   /// ### Examples
   /// ```no_run
-  /// use athena_interface::MockHost;
   /// use athena_sdk::{ExecutionClient, AthenaStdin};
   ///
   /// // Load the program.
@@ -49,13 +48,13 @@ impl ExecutionClient {
   /// stdin.write(&10usize);
   ///
   /// // Execute the program on the inputs.
-  /// let (public_values, gas_left) = client.execute::<MockHost>(elf, stdin, None, None, None).unwrap();
+  /// let (public_values, gas_left) = client.execute(elf, stdin, None, None, None).unwrap();
   /// ```
-  pub fn execute<T: HostInterface>(
+  pub fn execute(
     &self,
     elf: &[u8],
     stdin: AthenaStdin,
-    host: Option<&mut T>,
+    host: Option<&mut dyn HostInterface>,
     max_gas: Option<u32>,
     context: Option<AthenaContext>,
   ) -> Result<(AthenaPublicValues, Option<u32>), ExecutionError> {
@@ -96,9 +95,7 @@ mod tests {
     let elf = include_bytes!("../../examples/fibonacci/program/elf/fibonacci-program");
     let mut stdin = AthenaStdin::new();
     stdin.write(&10usize);
-    client
-      .execute::<MockHost>(elf, stdin, None, None, None)
-      .unwrap();
+    client.execute(elf, stdin, None, None, None).unwrap();
   }
 
   #[test]
@@ -121,9 +118,7 @@ mod tests {
     let client = ExecutionClient::new();
     let elf = include_bytes!("../../tests/host/elf/host-test");
     let stdin = AthenaStdin::new();
-    client
-      .execute::<MockHost>(elf, stdin, None, None, None)
-      .unwrap();
+    client.execute(elf, stdin, None, None, None).unwrap();
   }
 
   #[test]
@@ -134,8 +129,6 @@ mod tests {
     let elf = include_bytes!("../../tests/panic/elf/panic-test");
     let mut stdin = AthenaStdin::new();
     stdin.write(&10usize);
-    client
-      .execute::<MockHost>(elf, stdin, None, None, None)
-      .unwrap();
+    client.execute(elf, stdin, None, None, None).unwrap();
   }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -6,9 +6,6 @@ pub mod utils {
   pub use athena_core::utils::setup_logger;
 }
 
-use std::cell::RefCell;
-use std::sync::Arc;
-
 pub use athena_core::io::{AthenaPublicValues, AthenaStdin};
 use athena_core::runtime::{ExecutionError, Program, Runtime};
 use athena_core::utils::AthenaCoreOpts;
@@ -58,7 +55,7 @@ impl ExecutionClient {
     &self,
     elf: &[u8],
     stdin: AthenaStdin,
-    host: Option<Arc<RefCell<T>>>,
+    host: Option<&mut T>,
     max_gas: Option<u32>,
     context: Option<AthenaContext>,
   ) -> Result<(AthenaPublicValues, Option<u32>), ExecutionError> {
@@ -88,7 +85,6 @@ impl Default for ExecutionClient {
 
 #[cfg(test)]
 mod tests {
-  use std::{cell::RefCell, sync::Arc};
 
   use crate::{utils, AthenaStdin, ExecutionClient};
   use athena_interface::{AthenaContext, MockHost, ADDRESS_ALICE};
@@ -111,11 +107,10 @@ mod tests {
     let client = ExecutionClient::new();
     let elf = include_bytes!("../../tests/host/elf/host-test");
     let stdin = AthenaStdin::new();
-    #[allow(clippy::arc_with_non_send_sync)]
-    let host = Arc::new(RefCell::new(MockHost::new()));
+    let mut host = MockHost::new();
     let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
     client
-      .execute::<MockHost>(elf, stdin, Some(host), Some(1_000_000), Some(ctx))
+      .execute(elf, stdin, Some(&mut host), Some(1_000_000), Some(ctx))
       .unwrap();
   }
 


### PR DESCRIPTION
Two notable changes:
- the `Runtime` takes an exclusive reference to the host instead of `Arc<RefCell<HostInterface>`. It makes the code easier to reason about and lets the Rust borrow checker make sure that the borrow rules are not violated at runtime (the RefCell does it in runtime and might panic). I think it makes sense to require that the host outlives the runtime. It also allowed to remove the code of "stealing host" and later rebuilding it from the Arc.
- make the `Runtime` **not** generic over the `HostInterface` but use a dyn trait object instead. It simplifies the code a lot and removes the requirement to specify the host type when creating a runtime without a host (which led to using MockHost, where None host was passed).