### PR TITLE
fix memory leaks in AthconVm::execute

### DIFF
--- a/ffi/ffitest/src/lib.rs
+++ b/ffi/ffitest/src/lib.rs
@@ -4,13 +4,14 @@
 #[cfg(test)]
 mod ffi_tests {
   use std::collections::BTreeMap;
+  use std::rc::Rc;
 
   use athcon_client::host::HostContext as HostInterface;
   use athcon_client::types::{
     Address, Bytes, Bytes32, MessageKind, Revision, StatusCode, StorageStatus, ADDRESS_LENGTH,
     BYTES32_LENGTH,
   };
-  use athcon_client::{create, AthconVm};
+  use athcon_client::AthconVm;
   use athcon_sys as ffi;
   use athena_interface::ADDRESS_ALICE;
 
@@ -35,14 +36,14 @@ mod ffi_tests {
 
   struct HostContext {
     storage: BTreeMap<Bytes32, Bytes32>,
-    vm: AthconVm,
+    vm: Rc<AthconVm>,
   }
 
   impl HostContext {
     fn new(vm: AthconVm) -> HostContext {
       HostContext {
         storage: BTreeMap::new(),
-        vm,
+        vm: Rc::new(vm),
       }
     }
   }
@@ -126,11 +127,7 @@ mod ffi_tests {
         );
       }
 
-      // Create an owned copy of VM here to avoid borrow issues when passing self into execute
-      // Note: this clone duplicates the FFI handles, but we don't attempt to destroy them here.
-      // That'll be done using the original handles.
-      let vm = self.vm.clone();
-      let res = vm.execute(
+      let res = self.vm.clone().execute(
         self,
         Revision::ATHCON_FRONTIER,
         kind,
@@ -160,13 +157,11 @@ mod ffi_tests {
   /// it allows us to test talking to the VM via FFI, and that the host bindings work as expected.
   #[test]
   fn test_rust_host() {
-    let vm = create();
+    let vm = AthconVm::new();
     println!("Instantiate: {:?}", (vm.get_name(), vm.get_version()));
 
-    // Same proviso as above: we're cloning the pointers here, which is fine as long as we
-    // don't attempt to destroy them twice, or use the clone after we destroy the original.
-    let mut host = HostContext::new(vm.clone());
-    let (output, gas_left, status_code) = vm.execute(
+    let mut host = HostContext::new(vm);
+    let (output, gas_left, status_code) = host.vm.clone().execute(
       &mut host,
       Revision::ATHCON_FRONTIER,
       MessageKind::ATHCON_CALL,
@@ -184,6 +179,5 @@ mod ffi_tests {
     println!("Status:  {:?}", status_code);
     assert_eq!(status_code, StatusCode::ATHCON_SUCCESS);
     assert_eq!(u32::from_le_bytes(output.as_slice().try_into().unwrap()), 2);
-    vm.destroy();
   }
 }

--- a/ffi/ffitest/src/lib.rs
+++ b/ffi/ffitest/src/lib.rs
@@ -179,11 +179,11 @@ mod ffi_tests {
       &[0u8; BYTES32_LENGTH],
       CONTRACT_CODE,
     );
-    println!("Output:  {:?}", hex::encode(output));
+    println!("Output:  {:?}", hex::encode(&output));
     println!("GasLeft: {:?}", gas_left);
     println!("Status:  {:?}", status_code);
     assert_eq!(status_code, StatusCode::ATHCON_SUCCESS);
-    assert_eq!(output, 2u32.to_le_bytes().to_vec().as_slice());
+    assert_eq!(u32::from_le_bytes(output.as_slice().try_into().unwrap()), 2);
     vm.destroy();
   }
 }


### PR DESCRIPTION
Valgrind reports leaks:

```
LEAK SUMMARY:
   definitely lost: 716 bytes in 11 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 216 bytes in 1 blocks
   still reachable: 210,132 bytes in 582 blocks
        suppressed: 0 bytes in 0 blocks
```

The `athcon_message` allocated in `athcon_client::AthconVm::execute`:
```
512 bytes in 4 blocks are definitely lost in loss record 28 of 36
   at 0x4843866: malloc (vg_replace_malloc.c:446)
   by 0x625E1A: alloc::alloc::alloc (alloc.rs:100)
   by 0x625EFB: alloc::alloc::Global::alloc_impl (alloc.rs:183)
   by 0x625D5A: allocate (alloc.rs:243)
   by 0x625D5A: alloc::alloc::exchange_malloc (alloc.rs:332)
   by 0x624BF6: new<athcon_sys::athcon_message> (boxed.rs:259)
   by 0x624BF6: athcon_client::AthconVm::execute (lib.rs:61)
   by 0x30AD9E: <ffitest::ffi_tests::HostContext as athcon_client::host::HostContext>::call (lib.rs:133)
   by 0x62577E: athcon_client::host::call (host.rs:131)
   by 0x626D74: athcon_vm::ExecutionContext::call (lib.rs:293)
   by 0x30ECB5: <athena_vmlib::WrappedHostInterface as athena_interface::HostInterface>::call (lib.rs:475)
   by 0x33BC70: <athena_core::syscall::host::SyscallHostCall as athena_core::runtime::syscall::Syscall<T>>::execute (host.rs:163)
   by 0x31C7E3: athena_core::runtime::Runtime<T>::execute_instruction (mod.rs:556)
   by 0x319501: athena_core::runtime::Runtime<T>::execute_cycle (mod.rs:682)
```
and
```
128 bytes in 1 blocks are definitely lost in loss record 20 of 36
   at 0x4843866: malloc (vg_replace_malloc.c:446)
   by 0x625E1A: alloc::alloc::alloc (alloc.rs:100)
   by 0x625EFB: alloc::alloc::Global::alloc_impl (alloc.rs:183)
   by 0x625D5A: allocate (alloc.rs:243)
   by 0x625D5A: alloc::alloc::exchange_malloc (alloc.rs:332)
   by 0x624BF6: new<athcon_sys::athcon_message> (boxed.rs:259)
   by 0x624BF6: athcon_client::AthconVm::execute (lib.rs:61)
   by 0x30B10E: ffitest::ffi_tests::test_rust_host (lib.rs:169)
```

The `athcon_host_interface` allocated in `athcon_client::create`:
```
56 bytes in 1 blocks are definitely lost in loss record 10 of 36
   at 0x4843866: malloc (vg_replace_malloc.c:446)
   by 0x625E1A: alloc::alloc::alloc (alloc.rs:100)
   by 0x625EFB: alloc::alloc::Global::alloc_impl (alloc.rs:183)
   by 0x625D5A: allocate (alloc.rs:243)
   by 0x625D5A: alloc::alloc::exchange_malloc (alloc.rs:332)
   by 0x624D99: new<athcon_sys::athcon_host_interface> (boxed.rs:259)
   by 0x624D99: athcon_client::create (lib.rs:101)
   by 0x30AE7F: ffitest::ffi_tests::test_rust_host (lib.rs:163)

```

The `output` allocated for the execution result:
```
16 bytes in 4 blocks are definitely lost in loss record 5 of 36
   at 0x4843866: malloc (vg_replace_malloc.c:446)
   by 0x627B7A: alloc::alloc::alloc (alloc.rs:100)
   by 0x6270C9: athcon_vm::allocate_output_data (lib.rs:340)
   by 0x628DC0: athcon_vm::<impl core::convert::From<athcon_vm::ExecutionResult> for athcon_sys::athcon_result>::from (lib.rs:381)
   by 0x627F1D: <T as core::convert::Into<U>>::into (mod.rs:759)
   by 0x310B11: athena_vmlib::__athcon_execute (lib.rs:16)
   by 0x624CF6: athcon_client::AthconVm::execute (lib.rs:78)
   by 0x30AD9E: <ffitest::ffi_tests::HostContext as athcon_client::host::HostContext>::call (lib.rs:133)
   by 0x62577E: athcon_client::host::call (host.rs:131)
   by 0x626D74: athcon_vm::ExecutionContext::call (lib.rs:293)
   by 0x30ECB5: <athena_vmlib::WrappedHostInterface as athena_interface::HostInterface>::call (lib.rs:475)
   by 0x33BC70: <athena_core::syscall::host::SyscallHostCall as athena_core::runtime::syscall::Syscall<T>>::execute (host.rs:163)
```
and
```
4 bytes in 1 blocks are definitely lost in loss record 2 of 36
   at 0x4843866: malloc (vg_replace_malloc.c:446)
   by 0x627B7A: alloc::alloc::alloc (alloc.rs:100)
   by 0x6270C9: athcon_vm::allocate_output_data (lib.rs:340)
   by 0x628DC0: athcon_vm::<impl core::convert::From<athcon_vm::ExecutionResult> for athcon_sys::athcon_result>::from (lib.rs:381)
   by 0x627F1D: <T as core::convert::Into<U>>::into (mod.rs:759)
   by 0x310B11: athena_vmlib::__athcon_execute (lib.rs:16)
   by 0x624CF6: athcon_client::AthconVm::execute (lib.rs:78)
   by 0x30B10E: ffitest::ffi_tests::test_rust_host (lib.rs:169)
```

Also fix the improper allocation of 0 bytes, when the result output is empty:
```
0 bytes in 1 blocks are definitely lost in loss record 1 of 32
   at 0x484BE28: posix_memalign (vg_replace_malloc.c:2216)
   by 0x650170: aligned_malloc (alloc.rs:84)
   by 0x650170: alloc (alloc.rs:28)
   by 0x650170: __rdl_alloc (alloc.rs:400)
   by 0x62839A: alloc::alloc::alloc (alloc.rs:100)
   by 0x6278E9: athcon_vm::allocate_output_data (lib.rs:340)
   by 0x6295E0: athcon_vm::<impl core::convert::From<athcon_vm::ExecutionResult> for athcon_sys::athcon_result>::from (lib.rs:381)
   by 0x62873D: <T as core::convert::Into<U>>::into (mod.rs:759)
   by 0x3116B1: athena_vmlib::__athcon_execute (lib.rs:16)
   by 0x310803: athena_vmlib::vm_tests (lib.rs:638)
   by 0x30B70F: ffitest::ffi_tests::test_athcon_create (lib.rs:33)
```