### PR TITLE
add missing athcon status_code cases

### DIFF
--- a/ffi/athcon/include/athcon/helpers.h
+++ b/ffi/athcon/include/athcon/helpers.h
@@ -257,6 +257,10 @@ extern "C"
       return "rejected";
     case ATHCON_OUT_OF_MEMORY:
       return "out of memory";
+    case ATHCON_INSUFFICIENT_INPUT:
+      return "insufficient input";
+    case ATHCON_INVALID_SYSCALL_ARGUMENT:
+      return "invalid syscall argument";
     }
     return "<unknown>";
   }


### PR DESCRIPTION
Fixes errors reported when building Go athena connector:

```
# github.com/athenavm/athena/ffi/athcon/bindings/go [github.com/athenavm/athena/ffi/athcon/bindings/go.test]
In file included from host.go:7,
                 from _cgo_export.c:4:
./../../include/athcon/helpers.h: In function ‘athcon_status_code_to_string’:
./../../include/athcon/helpers.h:216:5: warning: enumeration value ‘ATHCON_INSUFFICIENT_INPUT’ not handled in switch [-Wswitch]
  216 |     switch (status_code)
      |     ^~~~~~
./../../include/athcon/helpers.h:216:5: warning: enumeration value ‘ATHCON_INVALID_SYSCALL_ARGUMENT’ not handled in switch [-Wswitch]
# github.com/athenavm/athena/ffi/athcon/bindings/go [github.com/athenavm/athena/ffi/athcon/bindings/go.test]
In file included from ./athcon.go:8:
./../../include/athcon/helpers.h: In function ‘athcon_status_code_to_string’:
./../../include/athcon/helpers.h:216:5: warning: enumeration value ‘ATHCON_INSUFFICIENT_INPUT’ not handled in switch [-Wswitch]
  216 |     switch (status_code)
      |     ^~~~~~
./../../include/athcon/helpers.h:216:5: warning: enumeration value ‘ATHCON_INVALID_SYSCALL_ARGUMENT’ not handled in switch [-Wswitch]
# github.com/athenavm/athena/ffi/athcon/bindings/go [github.com/athenavm/athena/ffi/athcon/bindings/go.test]
In file included from ./host.go:7:
./../../include/athcon/helpers.h: In function ‘athcon_status_code_to_string’:
./../../include/athcon/helpers.h:216:5: warning: enumeration value ‘ATHCON_INSUFFICIENT_INPUT’ not handled in switch [-Wswitch]
  216 |     switch (status_code)
      |     ^~~~~~
./../../include/athcon/helpers.h:216:5: warning: enumeration value ‘ATHCON_INVALID_SYSCALL_ARGUMENT’ not handled in switch [-Wswitch]
```