### PR TITLE
Fix unsound pointer conversions in Go bindings

### DIFF
--- a/ffi/athcon/bindings/go/athcon.go
+++ b/ffi/athcon/bindings/go/athcon.go
@@ -189,15 +189,9 @@ func (vm *VM) Execute(
 		// Otherwise, the Go garbage collector may move the data around and
 		// invalidate the pointer passed to the C code.
 		// Without this, the CGO complains `cgo argument has Go pointer to unpinned Go pointer`.
-		cInputData := C.malloc(C.size_t(len(input)))
-		if cInputData == nil {
-			return res, fmt.Errorf("failed to allocate memory for input data")
-		}
+		cInputData := C.CBytes(input)
 		defer C.free(cInputData)
-
-		cSlice := unsafe.Slice((*byte)(cInputData), len(input))
-		copy(cSlice, input)
-		msg.input_data = (*C.uchar)(unsafe.Pointer(&cSlice[0]))
+		msg.input_data = (*C.uchar)(cInputData)
 		msg.input_size = C.size_t(len(input))
 	}
 
@@ -207,7 +201,7 @@ func (vm *VM) Execute(
 	result := C.athcon_execute(
 		vm.handle,
 		hostInterface,
-		(*C.struct_athcon_host_context)(unsafe.Pointer(uintptr(ctxHandle))),
+		(*C.struct_athcon_host_context)(unsafe.Pointer(&ctxHandle)),
 		uint32(rev),
 		&msg,
 		(*C.uint8_t)(unsafe.Pointer(&code[0])),

--- a/ffi/athcon/bindings/go/host.go
+++ b/ffi/athcon/bindings/go/host.go
@@ -92,31 +92,31 @@ type HostContext interface {
 
 //export accountExists
 func accountExists(pCtx unsafe.Pointer, pAddr *C.athcon_address) C.bool {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 	return C.bool(ctx.AccountExists(goAddress(*pAddr)))
 }
 
 //export getStorage
 func getStorage(pCtx unsafe.Pointer, pAddr *C.athcon_address, pKey *C.athcon_bytes32) C.athcon_bytes32 {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 	return athconBytes32(ctx.GetStorage(goAddress(*pAddr), goHash(*pKey)))
 }
 
 //export setStorage
 func setStorage(pCtx unsafe.Pointer, pAddr *C.athcon_address, pKey *C.athcon_bytes32, pVal *C.athcon_bytes32) C.enum_athcon_storage_status {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 	return C.enum_athcon_storage_status(ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal)))
 }
 
 //export getBalance
 func getBalance(pCtx unsafe.Pointer, pAddr *C.athcon_address) C.athcon_uint256be {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 	return athconBytes32(ctx.GetBalance(goAddress(*pAddr)))
 }
 
 //export getTxContext
 func getTxContext(pCtx unsafe.Pointer) C.struct_athcon_tx_context {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 	txContext := ctx.GetTxContext()
 
 	return C.struct_athcon_tx_context{
@@ -131,13 +131,13 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_athcon_tx_context {
 
 //export getBlockHash
 func getBlockHash(pCtx unsafe.Pointer, number int64) C.athcon_bytes32 {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 	return athconBytes32(ctx.GetBlockHash(number))
 }
 
 //export call
 func call(pCtx unsafe.Pointer, msg *C.struct_athcon_message) C.struct_athcon_result {
-	ctx := cgo.Handle(pCtx).Value().(HostContext)
+	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 
 	kind := CallKind(msg.kind)
 	output, gasLeft, createAddr, err := ctx.Call(kind, goAddress(msg.recipient), goAddress(msg.sender), goHash(msg.value),


### PR DESCRIPTION
Invalid conversion from `cgo.Handler` to the opaque type `struct athcon_host_context*` blew up on arm64 mac.

See https://pkg.go.dev/runtime/cgo#Handle for details, especially: 

> Some C functions accept a void* argument that points to an arbitrary data value supplied by the caller. It is not safe to coerce a [cgo.Handle](https://pkg.go.dev/runtime/cgo#Handle) (an integer) to a Go [unsafe.Pointer](https://pkg.go.dev/unsafe#Pointer), but instead we can pass the address of the cgo.Handle to the void* parameter

I changed the Go bindings to follow the recommendation in the cgo docs.