### PR TITLE
scheduled cargo-audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,17 @@
+name: Security audit
+on:
+  merge_group:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add an audit workflow that will run [cargo-audit](https://github.com/rustsec/audit-check):
- 12:00 AM (midnight) UTC every day
- on changes to Cargo.toml and Cargo.lock 