### PR TITLE
Go bindings data structures

### DIFF
--- a/ffi/athcon/bindings/go/host_test.go
+++ b/ffi/athcon/bindings/go/host_test.go
@@ -45,10 +45,8 @@ func (host *testHostContext) GetBlockHash(number int64) Bytes32 {
 	return Bytes32{}
 }
 
-func (host *testHostContext) Call(kind CallKind,
-	recipient Address, sender Address, value Bytes32, input []byte, gas int64, depth int) (
-	output []byte, gasLeft int64, createAddr Address, err error) {
-	return nil, gas, Address{}, nil
+func (host *testHostContext) Call(msg AthconMessage) AthconResult {
+	return AthconResult{Status: AthconSuccess, GasLeft: msg.Gas}
 }
 
 func (host *testHostContext) Spawn(blob []byte) Address {
@@ -91,7 +89,7 @@ func TestGetBalance(t *testing.T) {
 	}
 }
 
-func TestCall(t *testing.T) {
+func TestExecute(t *testing.T) {
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 


### PR DESCRIPTION
Modifies go host test to use the same underlying data structures as the C types. This is one possible approach to a regression test for the issue fixed in #119. Not sure we actually want to merge this. Another possible approach was described in https://github.com/athenavm/athena/pull/119#issuecomment-2396658412.

This mimics the main host interface on the Rust side:

https://github.com/athenavm/athena/blob/e8b132da055f60acd2ac54fd294834e570ea9ba5/interface/src/lib.rs#L316-L323

although the (unused) Rust bindings are different:

https://github.com/athenavm/athena/blob/e8b132da055f60acd2ac54fd294834e570ea9ba5/ffi/athcon/bindings/rust/athcon-client/src/host.rs#L10-L31