### PR TITLE
Update C API to use uint64_t instead of uint256be where it makes sense

### DIFF
--- a/ffi/athcon/bindings/go/athcon.go
+++ b/ffi/athcon/bindings/go/athcon.go
@@ -171,7 +171,7 @@ func (vm *VM) Execute(
 	recipient, sender Address,
 	input []byte,
 	method []byte,
-	value Bytes32,
+	value uint64,
 	code []byte,
 ) (res Result, err error) {
 	if len(code) == 0 {
@@ -183,7 +183,7 @@ func (vm *VM) Execute(
 		gas:       C.int64_t(gas),
 		recipient: athconAddress(recipient),
 		sender:    athconAddress(sender),
-		value:     athconBytes32(value),
+		value:     C.uint64_t(value),
 	}
 	if len(input) > 0 {
 		// Allocate memory for input data in C.

--- a/ffi/athcon/bindings/go/athcon_test.go
+++ b/ffi/athcon/bindings/go/athcon_test.go
@@ -57,8 +57,7 @@ func TestExecuteEmptyCode(t *testing.T) {
 	defer vm.Destroy()
 
 	addr := Address{}
-	h := Bytes32{}
-	result, err := vm.Execute(nil, Frontier, Call, 1, 999, addr, addr, nil, nil, h, nil)
+	result, err := vm.Execute(nil, Frontier, Call, 1, 999, addr, addr, nil, nil, 0, nil)
 
 	require.Error(t, err)
 	require.Empty(t, result.Output)

--- a/ffi/athcon/bindings/go/host.go
+++ b/ffi/athcon/bindings/go/host.go
@@ -11,7 +11,7 @@ package athcon
 bool accountExists(void *ctx, athcon_address *addr);
 athcon_bytes32 getStorage(void *ctx, athcon_address *addr, athcon_bytes32 *key);
 enum athcon_storage_status setStorage(void *ctx, athcon_address *addr, athcon_bytes32 *key, athcon_bytes32 *val);
-athcon_uint256be getBalance(void *ctx, athcon_address *addr);
+uint64_t getBalance(void *ctx, athcon_address *addr);
 struct athcon_tx_context getTxContext(void *ctx);
 athcon_bytes32 getBlockHash(void *ctx, long long int number);
 struct athcon_result call(void *ctx, struct athcon_message *msg);
@@ -68,7 +68,7 @@ func goByteSlice(data *C.uint8_t, size C.size_t) []byte {
 
 // TxContext contains information about current transaction and block.
 type TxContext struct {
-	GasPrice    Bytes32
+	GasPrice    uint64
 	Origin      Address
 	Coinbase    Address
 	BlockHeight int64
@@ -81,10 +81,10 @@ type HostContext interface {
 	AccountExists(addr Address) bool
 	GetStorage(addr Address, key Bytes32) Bytes32
 	SetStorage(addr Address, key Bytes32, value Bytes32) StorageStatus
-	GetBalance(addr Address) Bytes32
+	GetBalance(addr Address) uint64
 	GetTxContext() TxContext
 	GetBlockHash(number int64) Bytes32
-	Call(kind CallKind, recipient Address, sender Address, value Bytes32, input []byte, method []byte, gas int64, depth int) (
+	Call(kind CallKind, recipient Address, sender Address, value uint64, input []byte, method []byte, gas int64, depth int) (
 		output []byte, gasLeft int64, createAddr Address, err error)
 	Spawn(blob []byte) Address
 	Deploy(code []byte) Address
@@ -109,9 +109,9 @@ func setStorage(pCtx unsafe.Pointer, pAddr *C.athcon_address, pKey *C.athcon_byt
 }
 
 //export getBalance
-func getBalance(pCtx unsafe.Pointer, pAddr *C.athcon_address) C.athcon_uint256be {
+func getBalance(pCtx unsafe.Pointer, pAddr *C.athcon_address) C.uint64_t {
 	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
-	return athconBytes32(ctx.GetBalance(goAddress(*pAddr)))
+	return C.uint64_t(ctx.GetBalance(goAddress(*pAddr)))
 }
 
 //export getTxContext
@@ -120,7 +120,7 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_athcon_tx_context {
 	txContext := ctx.GetTxContext()
 
 	return C.struct_athcon_tx_context{
-		athconBytes32(txContext.GasPrice),
+		C.uint64_t(txContext.GasPrice),
 		athconAddress(txContext.Origin),
 		C.int64_t(txContext.BlockHeight),
 		C.int64_t(txContext.Timestamp),
@@ -140,7 +140,7 @@ func call(pCtx unsafe.Pointer, msg *C.struct_athcon_message) C.struct_athcon_res
 	ctx := (*cgo.Handle)(pCtx).Value().(HostContext)
 
 	kind := CallKind(msg.kind)
-	output, gasLeft, createAddr, err := ctx.Call(kind, goAddress(msg.recipient), goAddress(msg.sender), goHash(msg.value),
+	output, gasLeft, createAddr, err := ctx.Call(kind, goAddress(msg.recipient), goAddress(msg.sender), uint64(msg.value),
 		goByteSlice(msg.input_data, msg.input_size), goByteSlice(msg.method_name, msg.method_name_size), int64(msg.gas), int(msg.depth))
 
 	statusCode := C.enum_athcon_status_code(0)

--- a/ffi/athcon/bindings/go/host_test.go
+++ b/ffi/athcon/bindings/go/host_test.go
@@ -29,10 +29,8 @@ func (host *testHostContext) SetStorage(addr Address, key Bytes32, value Bytes32
 	return StorageAdded
 }
 
-func (host *testHostContext) GetBalance(addr Address) Bytes32 {
-	var b Bytes32
-	binary.LittleEndian.PutUint32(b[:], 42)
-	return b
+func (host *testHostContext) GetBalance(addr Address) uint64 {
+	return 42
 }
 
 func (host *testHostContext) GetTxContext() TxContext {
@@ -46,7 +44,7 @@ func (host *testHostContext) GetBlockHash(number int64) Bytes32 {
 }
 
 func (host *testHostContext) Call(kind CallKind,
-	recipient Address, sender Address, value Bytes32, input []byte, method []byte, gas int64, depth int) (
+	recipient Address, sender Address, value uint64, input []byte, method []byte, gas int64, depth int) (
 	output []byte, gasLeft int64, createAddr Address, err error) {
 	return nil, gas, Address{}, nil
 }
@@ -67,8 +65,7 @@ func TestGetBalance(t *testing.T) {
 
 	host := &testHostContext{}
 	addr := Address{}
-	h := Bytes32{}
-	result, err := vm.Execute(host, Frontier, Call, 1, 100, addr, addr, nil, nil, h, MINIMAL_TEST_CODE)
+	result, err := vm.Execute(host, Frontier, Call, 1, 100, addr, addr, nil, nil, 0, MINIMAL_TEST_CODE)
 	output := result.Output
 	gasLeft := result.GasLeft
 
@@ -97,8 +94,7 @@ func TestCall(t *testing.T) {
 
 	host := &testHostContext{}
 	addr := Address{}
-	h := Bytes32{}
-	result, err := vm.Execute(host, Frontier, Call, 1, 10000, addr, addr, []byte{2, 0, 0, 0}, nil, h, RECURSIVE_CALL_TEST)
+	result, err := vm.Execute(host, Frontier, Call, 1, 10000, addr, addr, []byte{2, 0, 0, 0}, nil, 0, RECURSIVE_CALL_TEST)
 	output := result.Output
 
 	if len(output) != 4 {

--- a/ffi/athcon/bindings/rust/athcon-client/src/host.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/src/host.rs
@@ -12,7 +12,7 @@ pub trait HostContext {
   fn get_storage(&self, addr: &Address, key: &Bytes32) -> Bytes32;
   fn set_storage(&mut self, addr: &Address, key: &Bytes32, value: &Bytes32) -> StorageStatus;
   fn get_balance(&self, addr: &Address) -> u64;
-  fn get_tx_context(&self) -> (Bytes32, Address, i64, i64, i64, Bytes32);
+  fn get_tx_context(&self) -> (u64, Address, i64, i64, i64, Bytes32);
   fn get_block_hash(&self, number: i64) -> Bytes32;
   fn spawn(&mut self, blob: &[u8]) -> Address;
   fn deploy(&mut self, blob: &[u8]) -> Address;
@@ -93,7 +93,7 @@ unsafe extern "C" fn get_tx_context(
   let (gas_price, origin, height, timestamp, gas_limit, chain_id) =
     (*(context as *mut ExtendedContext)).hctx.get_tx_context();
   ffi::athcon_tx_context {
-    tx_gas_price: athcon_sys::athcon_bytes32 { bytes: gas_price },
+    tx_gas_price: gas_price,
     tx_origin: athcon_sys::athcon_address { bytes: origin },
     block_height: height,
     block_timestamp: timestamp,

--- a/ffi/athcon/bindings/rust/athcon-client/src/host.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/src/host.rs
@@ -11,7 +11,7 @@ pub trait HostContext {
   fn account_exists(&self, addr: &Address) -> bool;
   fn get_storage(&self, addr: &Address, key: &Bytes32) -> Bytes32;
   fn set_storage(&mut self, addr: &Address, key: &Bytes32, value: &Bytes32) -> StorageStatus;
-  fn get_balance(&self, addr: &Address) -> Bytes32;
+  fn get_balance(&self, addr: &Address) -> u64;
   fn get_tx_context(&self) -> (Bytes32, Address, i64, i64, i64, Bytes32);
   fn get_block_hash(&self, number: i64) -> Bytes32;
   fn spawn(&mut self, blob: &[u8]) -> Address;
@@ -22,7 +22,7 @@ pub trait HostContext {
     kind: MessageKind,
     recipient: &Address,
     sender: &Address,
-    value: &Bytes32,
+    value: u64,
     input: &Bytes,
     method: &Bytes,
     gas: i64,
@@ -81,12 +81,10 @@ unsafe extern "C" fn set_storage(
 unsafe extern "C" fn get_balance(
   context: *mut ffi::athcon_host_context,
   address: *const ffi::athcon_address,
-) -> ffi::athcon_uint256be {
-  ffi::athcon_uint256be {
-    bytes: (*(context as *mut ExtendedContext))
-      .hctx
-      .get_balance(&(*address).bytes),
-  }
+) -> u64 {
+  (*(context as *mut ExtendedContext))
+    .hctx
+    .get_balance(&(*address).bytes)
 }
 
 unsafe extern "C" fn get_tx_context(
@@ -161,7 +159,7 @@ pub unsafe extern "C" fn call(
       msg.kind,
       &msg.recipient.bytes,
       &msg.sender.bytes,
-      &msg.value.bytes,
+      msg.value,
       if !msg.input_data.is_null() && msg.input_size > 0 {
         std::slice::from_raw_parts(msg.input_data, msg.input_size)
       } else {

--- a/ffi/athcon/bindings/rust/athcon-client/src/lib.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/src/lib.rs
@@ -54,7 +54,7 @@ impl AthconVm {
     sender: &Address,
     input: &[u8],
     method: &[u8],
-    value: &[u8; 32],
+    value: u64,
     code: &[u8],
   ) -> (Vec<u8>, i64, StatusCode) {
     let ext_ctx = host::ExtendedContext { hctx: ctx };
@@ -70,7 +70,7 @@ impl AthconVm {
       input_size: input.len(),
       method_name: method.as_ptr(),
       method_name_size: method.len(),
-      value: ffi::athcon_uint256be { bytes: *value },
+      value,
       code: code.as_ptr(),
       code_size: code.len(),
     };

--- a/ffi/athcon/bindings/rust/athcon-client/tests/integration_tests.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/tests/integration_tests.rs
@@ -52,9 +52,9 @@ impl HostInterface for HostContext {
     StorageStatus::ATHCON_STORAGE_MODIFIED
   }
 
-  fn get_balance(&self, _addr: &Address) -> Bytes32 {
+  fn get_balance(&self, _addr: &Address) -> u64 {
     println!("Host: get_balance");
-    [0u8; BYTES32_LENGTH]
+    0
   }
 
   fn get_tx_context(&self) -> (Bytes32, Address, i64, i64, i64, Bytes32) {
@@ -79,7 +79,7 @@ impl HostInterface for HostContext {
     kind: MessageKind,
     destination: &Address,
     sender: &Address,
-    value: &Bytes32,
+    value: u64,
     input: &Bytes,
     method: &Bytes,
     gas: i64,
@@ -161,7 +161,7 @@ fn test_rust_host() {
     3u32.to_le_bytes().as_slice(),
     // empty method name
     &[],
-    &[0u8; BYTES32_LENGTH],
+    0,
     CONTRACT_CODE,
   );
   println!("Output:  {:?}", hex::encode(&output));

--- a/ffi/athcon/bindings/rust/athcon-client/tests/integration_tests.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/tests/integration_tests.rs
@@ -57,16 +57,9 @@ impl HostInterface for HostContext {
     0
   }
 
-  fn get_tx_context(&self) -> (Bytes32, Address, i64, i64, i64, Bytes32) {
+  fn get_tx_context(&self) -> (u64, Address, i64, i64, i64, Bytes32) {
     println!("Host: get_tx_context");
-    (
-      [0u8; BYTES32_LENGTH],
-      [0u8; ADDRESS_LENGTH],
-      0,
-      0,
-      0,
-      [0u8; BYTES32_LENGTH],
-    )
+    (0, [0u8; ADDRESS_LENGTH], 0, 0, 0, [0u8; BYTES32_LENGTH])
   }
 
   fn get_block_hash(&self, _number: i64) -> Bytes32 {

--- a/ffi/athcon/bindings/rust/athcon-vm/src/container.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/container.rs
@@ -90,7 +90,7 @@ mod tests {
     _context: *mut athcon_sys::athcon_host_context,
   ) -> athcon_sys::athcon_tx_context {
     athcon_sys::athcon_tx_context {
-      tx_gas_price: Uint256::default(),
+      tx_gas_price: 0,
       tx_origin: Address::default(),
       block_height: 0,
       block_timestamp: 0,

--- a/ffi/athcon/bindings/rust/athcon-vm/src/container.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/container.rs
@@ -123,7 +123,7 @@ mod tests {
       input_size: 0,
       method_name: std::ptr::null(),
       method_name_size: 0,
-      value: ::athcon_sys::athcon_uint256be::default(),
+      value: 0,
       code: std::ptr::null(),
       code_size: 0,
     };

--- a/ffi/athcon/bindings/rust/athcon-vm/src/lib.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/lib.rs
@@ -760,7 +760,7 @@ mod tests {
     _context: *mut ffi::athcon_host_context,
   ) -> ffi::athcon_tx_context {
     ffi::athcon_tx_context {
-      tx_gas_price: Uint256 { bytes: [0u8; 32] },
+      tx_gas_price: 0,
       tx_origin: Address { bytes: [0u8; 24] },
       block_height: 42,
       block_timestamp: 235117,

--- a/ffi/athcon/bindings/rust/athcon-vm/src/lib.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/lib.rs
@@ -56,7 +56,7 @@ pub struct ExecutionMessage {
   sender: Address,
   input: Option<Vec<u8>>,
   method: Option<Vec<u8>>,
-  value: Uint256,
+  value: u64,
   code: Option<Vec<u8>>,
 }
 
@@ -128,7 +128,7 @@ impl ExecutionMessage {
     sender: Address,
     input: Option<&[u8]>,
     method: Option<&[u8]>,
-    value: Uint256,
+    value: u64,
     code: Option<&[u8]>,
   ) -> Self {
     ExecutionMessage {
@@ -180,8 +180,8 @@ impl ExecutionMessage {
   }
 
   /// Read the value of the message.
-  pub fn value(&self) -> &Uint256 {
-    &self.value
+  pub fn value(&self) -> u64 {
+    self.value
   }
 
   /// Read the optional init code.
@@ -241,7 +241,7 @@ impl<'a> ExecutionContext<'a> {
   }
 
   /// Get balance of an account.
-  pub fn get_balance(&self, address: &Address) -> Uint256 {
+  pub fn get_balance(&self, address: &Address) -> u64 {
     unsafe {
       assert!(self.host.get_balance.is_some());
       self.host.get_balance.unwrap()(self.context, address as *const Address)
@@ -282,7 +282,7 @@ impl<'a> ExecutionContext<'a> {
       input_size,
       method_name,
       method_name_size,
-      value: *message.value(),
+      value: message.value,
       code: code_data,
       code_size,
     };
@@ -599,7 +599,7 @@ mod tests {
     let input = vec![0xc0, 0xff, 0xee];
     let recipient = Address { bytes: [32u8; 24] };
     let sender = Address { bytes: [128u8; 24] };
-    let value = Uint256 { bytes: [0u8; 32] };
+    let value = 77;
 
     let ret = ExecutionMessage::new(
       MessageKind::ATHCON_CALL,
@@ -620,14 +620,14 @@ mod tests {
     assert_eq!(*ret.sender(), sender);
     assert!(ret.input().is_some());
     assert_eq!(*ret.input().unwrap(), input);
-    assert_eq!(*ret.value(), value);
+    assert_eq!(ret.value, value);
   }
 
   #[test]
   fn message_new_with_code() {
     let recipient = Address { bytes: [32u8; 24] };
     let sender = Address { bytes: [128u8; 24] };
-    let value = Uint256 { bytes: [0u8; 32] };
+    let value = 0;
     let code = vec![0x5f, 0x5f, 0xfd];
 
     let ret = ExecutionMessage::new(
@@ -647,7 +647,7 @@ mod tests {
     assert_eq!(ret.gas(), 4466);
     assert_eq!(*ret.recipient(), recipient);
     assert_eq!(*ret.sender(), sender);
-    assert_eq!(*ret.value(), value);
+    assert_eq!(ret.value, value);
     assert!(ret.code().is_some());
     assert_eq!(*ret.code().unwrap(), code);
   }
@@ -655,7 +655,7 @@ mod tests {
   fn valid_athcon_message() -> ffi::athcon_message {
     let recipient = Address { bytes: [32u8; 24] };
     let sender = Address { bytes: [128u8; 24] };
-    let value = Uint256 { bytes: [0u8; 32] };
+    let value = 0;
 
     ffi::athcon_message {
       kind: MessageKind::ATHCON_CALL,
@@ -684,7 +684,7 @@ mod tests {
     assert_eq!(*ret.recipient(), msg.recipient);
     assert_eq!(*ret.sender(), msg.sender);
     assert!(ret.input().is_none());
-    assert_eq!(*ret.value(), msg.value);
+    assert_eq!(ret.value, msg.value);
     assert!(ret.code().is_none());
   }
 
@@ -707,7 +707,7 @@ mod tests {
     assert_eq!(*ret.sender(), msg.sender);
     assert!(ret.input().is_some());
     assert_eq!(*ret.input().unwrap(), input);
-    assert_eq!(*ret.value(), msg.value);
+    assert_eq!(ret.value, msg.value);
     assert!(ret.code().is_none());
   }
 
@@ -729,7 +729,7 @@ mod tests {
     assert_eq!(*ret.recipient(), msg.recipient);
     assert_eq!(*ret.sender(), msg.sender);
     assert!(ret.input().is_none());
-    assert_eq!(*ret.value(), msg.value);
+    assert_eq!(ret.value, msg.value);
     assert!(ret.code().is_some());
     assert_eq!(*ret.code().unwrap(), code);
   }
@@ -840,7 +840,7 @@ mod tests {
       test_addr,
       None,
       None,
-      Uint256::default(),
+      0,
       None,
     );
 
@@ -871,7 +871,7 @@ mod tests {
       test_addr,
       Some(&data),
       None,
-      Uint256::default(),
+      0,
       None,
     );
 

--- a/ffi/athcon/include/athcon/athcon.h
+++ b/ffi/athcon/include/athcon/athcon.h
@@ -148,7 +148,7 @@ extern "C"
   /** The transaction and block data for execution. */
   struct athcon_tx_context
   {
-    athcon_uint256be tx_gas_price; /**< The transaction gas price. */
+    uint64_t tx_gas_price;         /**< The transaction gas price. */
     athcon_address tx_origin;      /**< The transaction origin account. */
     int64_t block_height;          /**< The block height. */
     int64_t block_timestamp;       /**< The block timestamp. */

--- a/ffi/athcon/include/athcon/athcon.h
+++ b/ffi/athcon/include/athcon/athcon.h
@@ -132,7 +132,7 @@ extern "C"
      *
      * This is transferred value for ::ATHCON_CALL or apparent value for ::ATHCON_DELEGATECALL.
      */
-    athcon_uint256be value;
+    uint64_t value;
 
     /**
      * The code to be executed.
@@ -568,8 +568,8 @@ extern "C"
    * @param address  The address of the account.
    * @return         The balance of the given account or 0 if the account does not exist.
    */
-  typedef athcon_uint256be (*athcon_get_balance_fn)(struct athcon_host_context *context,
-                                                    const athcon_address *address);
+  typedef uint64_t (*athcon_get_balance_fn)(struct athcon_host_context *context,
+                                            const athcon_address *address);
 
   /**
    * Pointer to the callback function supporting Athena calls.

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -8,8 +8,8 @@ use athcon_vm::{
   SetOptionError,
 };
 use athena_interface::{
-  Address, AthenaMessage, AthenaRevision, Balance, Bytes32, Bytes32AsU64, ExecutionResult,
-  HostInterface, MessageKind, StatusCode, StorageStatus, TransactionContext, VmInterface,
+  Address, AthenaMessage, AthenaRevision, Balance, Bytes32, ExecutionResult, HostInterface,
+  MessageKind, StatusCode, StorageStatus, TransactionContext, VmInterface,
 };
 use athena_runner::AthenaVm;
 
@@ -109,12 +109,6 @@ impl From<Bytes32Wrapper> for ffi::athcon_bytes32 {
 impl From<Bytes32Wrapper> for Bytes32 {
   fn from(bytes: Bytes32Wrapper) -> Self {
     bytes.0
-  }
-}
-
-impl From<Bytes32Wrapper> for u64 {
-  fn from(bytes: Bytes32Wrapper) -> Self {
-    Bytes32AsU64::new(bytes.0).into()
   }
 }
 
@@ -444,7 +438,7 @@ impl From<TransactionContextWrapper> for TransactionContext {
   fn from(context: TransactionContextWrapper) -> Self {
     let tx_context = context.0;
     TransactionContext {
-      gas_price: Bytes32Wrapper::from(tx_context.tx_gas_price).into(),
+      gas_price: tx_context.tx_gas_price,
       origin: AddressWrapper::from(tx_context.tx_origin).into(),
       block_height: tx_context.block_height,
       block_timestamp: tx_context.block_timestamp,

--- a/ffi/vmlib/tests/integration_tests.rs
+++ b/ffi/vmlib/tests/integration_tests.rs
@@ -4,7 +4,7 @@ unsafe extern "C" fn get_dummy_tx_context(
   _context: *mut ffi::athcon_host_context,
 ) -> ffi::athcon_tx_context {
   ffi::athcon_tx_context {
-    tx_gas_price: athcon_vm::Uint256 { bytes: [0u8; 32] },
+    tx_gas_price: 0,
     tx_origin: athcon_vm::Address { bytes: [0u8; 24] },
     block_height: 42,
     block_timestamp: 235117,

--- a/ffi/vmlib/tests/integration_tests.rs
+++ b/ffi/vmlib/tests/integration_tests.rs
@@ -80,7 +80,7 @@ fn test_athcon_create() {
       input_size: 0,
       method_name: std::ptr::null(),
       method_name_size: 0,
-      value: ::athcon_sys::athcon_uint256be::default(),
+      value: 0,
       code: code.as_ptr(),
       code_size: code.len(),
     };

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -16,37 +16,6 @@ pub type Balance = u64;
 pub type Bytes32 = [u8; BYTES32_LENGTH];
 pub type Bytes = [u8];
 
-pub struct Bytes32AsU64(Bytes32);
-
-impl Bytes32AsU64 {
-  pub fn new(bytes: Bytes32) -> Self {
-    Bytes32AsU64(bytes)
-  }
-}
-
-impl From<Bytes32AsU64> for u64 {
-  fn from(bytes: Bytes32AsU64) -> Self {
-    // take most significant 8 bytes, assume little-endian
-    let slice = &bytes.0[..8];
-    u64::from_le_bytes(slice.try_into().expect("slice with incorrect length"))
-  }
-}
-
-impl From<Bytes32AsU64> for Bytes32 {
-  fn from(bytes: Bytes32AsU64) -> Self {
-    bytes.0
-  }
-}
-
-impl From<u64> for Bytes32AsU64 {
-  fn from(value: u64) -> Self {
-    let mut bytes = [0u8; 32];
-    let value_bytes = value.to_le_bytes();
-    bytes[..8].copy_from_slice(&value_bytes);
-    Bytes32AsU64(bytes)
-  }
-}
-
 pub struct AddressWrapper(Address);
 
 impl From<Vec<u32>> for AddressWrapper {


### PR DESCRIPTION
Closes #140.
Updated:
 - `get_balance()` to return `uint64_t`
 - `athcon_message::value` to `uint64_t` as it represents coins and is converted to uint64_t internally anyways
 - `athcon_tx_context::tx_gas_price` as it is converted to `uint64_t` internally