### PR TITLE
Give write permissions to create git tag in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     name: Prepare release
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     outputs:
       tag_name: ${{ steps.release_info.outputs.tag_name }}
       release_name: ${{ steps.release_info.outputs.release_name }}


### PR DESCRIPTION
Fixes #193 

Fixed release run: https://github.com/athenavm/athena/actions/runs/11572276571/job/32211912494