### PR TITLE
fix IS_NIGHTLY env uses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Compute release name and tag
         id: release_info
         run: |
-          if [[ $IS_NIGHTLY ]]; then
+          if [[ $IS_NIGHTLY == true ]]; then
             echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "release_name=Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF_NAME}" == "main" ]]; then
@@ -51,7 +51,7 @@ jobs:
       # which allows users to roll back. It is also used to build
       # the changelog.
       - name: Create build-specific nightly tag
-        if: ${{ env.IS_NIGHTLY }}
+        if: env.IS_NIGHTLY == true
         uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ steps.release_info.outputs.tag_name }}
@@ -69,7 +69,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: "./.github/changelog.json"
-          fromTag: ${{ env.IS_NIGHTLY && 'nightly' || '' }}
+          fromTag: ${{ env.IS_NIGHTLY == 'true' && 'nightly' || '' }}
           toTag: ${{ steps.release_info.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,7 +157,7 @@ jobs:
           PLATFORM_NAME: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
           ARCH: ${{ matrix.arch }}
-          VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
+          VERSION_NAME: ${{ (env.IS_NIGHTLY == 'true' && 'nightly') || needs.prepare.outputs.tag_name }}
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
@@ -202,7 +202,7 @@ jobs:
       # If this is a nightly release, it also updates the release
       # tagged `nightly` for compatibility with `foundryup`
       - name: Update nightly release
-        if: ${{ env.IS_NIGHTLY }}
+        if: env.IS_NIGHTLY == true
         uses: softprops/action-gh-release@v2
         with:
           name: "Nightly"
@@ -224,7 +224,7 @@ jobs:
 
       # Moves the `nightly` tag to `HEAD`
       - name: Move nightly tag
-        if: ${{ env.IS_NIGHTLY }}
+        if: env.IS_NIGHTLY == true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       # which allows users to roll back. It is also used to build
       # the changelog.
       - name: Create build-specific nightly tag
-        if: env.IS_NIGHTLY == true
+        if: env.IS_NIGHTLY == 'true'
         uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ steps.release_info.outputs.tag_name }}
@@ -202,7 +202,7 @@ jobs:
       # If this is a nightly release, it also updates the release
       # tagged `nightly` for compatibility with `foundryup`
       - name: Update nightly release
-        if: env.IS_NIGHTLY == true
+        if: env.IS_NIGHTLY == 'true'
         uses: softprops/action-gh-release@v2
         with:
           name: "Nightly"
@@ -218,13 +218,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: release
+    permissions:
+      contents: write # to delete a release
     if: always()
     steps:
       - uses: actions/checkout@v4
 
       # Moves the `nightly` tag to `HEAD`
       - name: Move nightly tag
-        if: env.IS_NIGHTLY == true
+        if: env.IS_NIGHTLY == 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Closes #200 

The existing uses of `IS_NIGHTLY` env were written in a way that works with the variable either set or not existing at all. The PR #170 enabled nightly builds by uncommenting:
```
env:
  IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
```

This version, however results in the `IS_NIGHTLY` variable **always** present with a value `true` or `false`. This causes the workflow to be in "nightly mode" always (see https://github.com/athenavm/athena/actions/runs/11572825493/job/32213626274).

This PR fixes uses of the variable in the release workflow to work with `IS_NIGHTLY=false|true`.

Non-nightly run (on v* tag, nightly steps are skipped): https://github.com/athenavm/athena/actions/runs/11575072142/job/32220789839
Nightly run (on workflow_dispatch): https://github.com/athenavm/athena/actions/runs/11575009673/job/32220734895