### PR TITLE
allow using `template` proc macro multiple times

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -80,14 +80,14 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athcon-sys"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bindgen",
 ]
 
 [[package]]
 name = "athcon-vm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "athcon-sys",
  "athena-interface",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "athena-builder"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "athena-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "athena-helper",
  "athena-interface",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "athena-helper"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "athena-builder",
  "cargo_metadata",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "athena-interface"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "athena-lib"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "athena-runner"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "athcon-sys",
  "athcon-vm",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "athena-sdk"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "athena-core",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "athena-interface",
  "athena-lib",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-sdk"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "athena-interface",
  "athena-vm",

--- a/examples/wallet/program/Cargo.toml
+++ b/examples/wallet/program/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 athena-interface = { path = "../../../interface" }
 athena-vm = { path = "../../../vm/entrypoint", features = [
-  "noentrypoint",
   "rv32e",
 ] }
 athena-vm-declare = { path = "../../../vm/declare" }

--- a/tests/entrypoint/Cargo.toml
+++ b/tests/entrypoint/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 athena-vm = { path = "../../vm/entrypoint", features = [
-  "noentrypoint",
   "rv32e",
 ] }
 athena-vm-declare = { path = "../../vm/declare" }

--- a/tests/entrypoint/src/main.rs
+++ b/tests/entrypoint/src/main.rs
@@ -1,8 +1,11 @@
 #![no_main]
+use athena_vm::entrypoint;
 use athena_vm_declare::{callable, template};
 use athena_vm_sdk::call;
 
 pub struct EntrypointTest {}
+
+athena_vm::entrypoint!();
 
 #[cfg(all(
   any(target_arch = "riscv32", target_arch = "riscv64"),

--- a/vm/declare/src/lib.rs
+++ b/vm/declare/src/lib.rs
@@ -42,7 +42,7 @@ pub fn template(_attr: TokenStream, item: TokenStream) -> TokenStream {
           #[no_mangle]
           pub unsafe extern "C" fn #c_func_name() {
             #call;
-            syscall_halt(0);
+            athena_vm::syscalls::syscall_halt(0);
           }
 
           // This black magic ensures the function symbol makes it into the final binary.
@@ -55,10 +55,6 @@ pub fn template(_attr: TokenStream, item: TokenStream) -> TokenStream {
   }
 
   let output = quote! {
-      // Basic Athena preamble, for use without a main entrypoint.
-      use athena_vm::syscalls::syscall_halt;
-      athena_vm::entrypoint!();
-
       #input
 
       #(#c_functions)*

--- a/vm/entrypoint/Cargo.toml
+++ b/vm/entrypoint/Cargo.toml
@@ -22,5 +22,4 @@ athena-lib = { path = "../lib", optional = true }
 [features]
 default = ["lib"]
 lib = ["dep:athena-lib"]
-noentrypoint = []
 rv32e = []

--- a/vm/entrypoint/src/lib.rs
+++ b/vm/entrypoint/src/lib.rs
@@ -21,31 +21,21 @@ pub mod types {
   pub use athena_interface::*;
 }
 
-// This macro should be used for libraries with multiple exported functions
-#[cfg(feature = "noentrypoint")]
+/// Define the program entrypoint.
+///
+/// Configures the global allocator and an optional entrypoint function.
+/// The entrypoint function is called by the runtime if no other method is
+/// explicitly selected.
 #[macro_export]
 macro_rules! entrypoint {
   () => {
-    use $crate::heap::SimpleAlloc;
-
-    #[global_allocator]
-    static HEAP: SimpleAlloc = SimpleAlloc;
-
-    mod vm_generated_main {
-      #[no_mangle]
-      fn main() {
-        panic!("noentrypoint feature is enabled");
-      }
+    fn main() {
+      panic!("No entrypoint found");
     }
+    entrypoint!(main);
   };
-}
-
-// This macro should be used for programs with a single entrypoint
-#[cfg(not(feature = "noentrypoint"))]
-#[macro_export]
-macro_rules! entrypoint {
-  ($path:path) => {
-    const VM_ENTRY: fn() = $path;
+  ($entry:path) => {
+    const VM_ENTRY: fn() = $entry;
 
     use $crate::heap::SimpleAlloc;
 


### PR DESCRIPTION
Closes #160 

Removed the `noentrypoint` feature. A program with no "main" can simply use `entrypoint!()` without a parameter. 

Changed the `template` macro to not include the entrypoint to allow using it multiple times in a program (look at the wallet template for a use case).