### PR TITLE
newtype for athena Address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -898,18 +898,18 @@ pub mod tests {
     setup_logger();
 
     // recipient address
-    let address = Address([0xCA; ADDRESS_LENGTH]);
+    let address = Address::from([0xCA; ADDRESS_LENGTH]);
 
     let amount_to_send = 1000;
 
     // arbitrary memory locations
     let memloc: u32 = 0x12345678;
-    let memloc2 = memloc.wrapping_add(address.0.len() as u32);
+    let memloc2 = memloc.wrapping_add(address.as_ref().len() as u32);
 
     let mut instructions = vec![];
 
     // write address to memory
-    for (i, word) in address.0.chunks_exact(4).enumerate() {
+    for (i, word) in address.as_ref().chunks_exact(4).enumerate() {
       instructions.push(Instruction::new(
         Opcode::ADD,
         Register::X16 as u32,

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -84,7 +84,7 @@ impl Syscall for SyscallHostCall {
 
     // note: the host is responsible for checking stack depth, not us
 
-    let address = Address(ctx.array(address_ptr));
+    let address = Address::from(ctx.array(address_ptr));
 
     // read the input length from the next register
     let len = ctx.rt.register(Register::X12) as usize;
@@ -215,7 +215,7 @@ impl Syscall for SyscallHostSpawn {
       .rt
       .rr(Register::X12, crate::runtime::MemoryAccessPosition::A);
 
-    for (idx, c) in address.0.chunks_exact(4).enumerate() {
+    for (idx, c) in address.as_ref().chunks_exact(4).enumerate() {
       let v = u32::from_le_bytes(c.try_into().unwrap());
       ctx.rt.mw(out_addr + idx as u32 * 4, v);
     }
@@ -248,7 +248,7 @@ impl Syscall for SyscallHostDeploy {
       .rt
       .rr(Register::X12, crate::runtime::MemoryAccessPosition::A);
 
-    for (idx, c) in address.0.chunks_exact(4).enumerate() {
+    for (idx, c) in address.as_ref().chunks_exact(4).enumerate() {
       let v = u32::from_le_bytes(c.try_into().unwrap());
       ctx.rt.mw(out_addr + idx as u32 * 4, v);
     }

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use crate::runtime::{Outcome, Register, Syscall, SyscallContext, SyscallResult};
 use athena_interface::{
-  AthenaMessage, Bytes32Wrapper, MessageKind, StatusCode, ADDRESS_LENGTH, BYTES32_LENGTH,
+  Address, AthenaMessage, Bytes32Wrapper, MessageKind, StatusCode, BYTES32_LENGTH,
 };
 
 pub(crate) struct SyscallHostRead;
@@ -84,7 +84,7 @@ impl Syscall for SyscallHostCall {
 
     // note: the host is responsible for checking stack depth, not us
 
-    let address: [u8; ADDRESS_LENGTH] = ctx.array(address_ptr);
+    let address = Address(ctx.array(address_ptr));
 
     // read the input length from the next register
     let len = ctx.rt.register(Register::X12) as usize;
@@ -215,7 +215,7 @@ impl Syscall for SyscallHostSpawn {
       .rt
       .rr(Register::X12, crate::runtime::MemoryAccessPosition::A);
 
-    for (idx, c) in address.chunks_exact(4).enumerate() {
+    for (idx, c) in address.0.chunks_exact(4).enumerate() {
       let v = u32::from_le_bytes(c.try_into().unwrap());
       ctx.rt.mw(out_addr + idx as u32 * 4, v);
     }
@@ -242,13 +242,13 @@ impl Syscall for SyscallHostDeploy {
         return Err(StatusCode::Failure);
       }
     };
-    tracing::debug!("deploy succeeded: {}", hex::encode(address));
+    tracing::debug!(%address, "deploy succeeded");
 
     let out_addr = ctx
       .rt
       .rr(Register::X12, crate::runtime::MemoryAccessPosition::A);
 
-    for (idx, c) in address.chunks_exact(4).enumerate() {
+    for (idx, c) in address.0.chunks_exact(4).enumerate() {
       let v = u32::from_le_bytes(c.try_into().unwrap());
       ctx.rt.mw(out_addr + idx as u32 * 4, v);
     }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arrayref"
@@ -249,7 +249,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -480,7 +480,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -504,7 +504,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -555,7 +555,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -677,9 +677,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gdbstub"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcc892208d6998fb57e7c3e05883def66f8130924bba066beb0cfe71566a9f6"
+checksum = "31c683a9f13de31432e6097131d5f385898c7f0635c0f392b9d0fa165063c8ac"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -935,7 +935,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1129,7 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ checksum = "54be4f245ce16bc58d57ef2716271d0d4519e0f6defa147f6e081005bcb278ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1400,7 +1400,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1422,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1445,22 +1445,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1568,7 +1568,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1874,7 +1874,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/examples/fibonacci/program/Cargo.lock
+++ b/examples/fibonacci/program/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/examples/hello_world/program/Cargo.lock
+++ b/examples/hello_world/program/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/examples/io/program/Cargo.lock
+++ b/examples/io/program/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/examples/wallet/program/Cargo.lock
+++ b/examples/wallet/program/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/examples/wallet/script/src/bin/execute.rs
+++ b/examples/wallet/script/src/bin/execute.rs
@@ -58,7 +58,7 @@ fn main() {
 
   let mut host = MockHost::new_with_context(
     HostStaticContext::new(ADDRESS_ALICE, 0, ADDRESS_ALICE),
-    HostDynamicContext::new([0u8; 24], ADDRESS_ALICE),
+    HostDynamicContext::new(Address::default(), ADDRESS_ALICE),
   );
   host.set_balance(&ADDRESS_ALICE, 10000);
   let address = spawn(&mut host, &args.owner).expect("spawning wallet program");

--- a/examples/wallet/script/src/bin/execute.rs
+++ b/examples/wallet/script/src/bin/execute.rs
@@ -68,7 +68,7 @@ fn main() {
   );
 
   // send some coins
-  let address_bob = Address([0xBB; 24]);
+  let address_bob = Address::from([0xBB; 24]);
   let context = AthenaContext::new(ADDRESS_ALICE, address_bob, 0);
 
   let mut stdin = AthenaStdin::new();

--- a/examples/wallet/script/src/bin/execute.rs
+++ b/examples/wallet/script/src/bin/execute.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 
 use athena_interface::{
   Address, AthenaContext, Encode, HostDynamicContext, HostInterface, HostStaticContext,
-  MethodSelector, MockHost, ADDRESS_ALICE, ADDRESS_BOB, ADDRESS_CHARLIE,
+  MethodSelector, MockHost, ADDRESS_ALICE, ADDRESS_CHARLIE,
 };
 use athena_sdk::{AthenaStdin, ExecutionClient};
 use athena_vm_sdk::{Pubkey, SpendArguments};
@@ -63,13 +63,13 @@ fn main() {
   host.set_balance(&ADDRESS_ALICE, 10000);
   let address = spawn(&mut host, &args.owner).expect("spawning wallet program");
   println!(
-    "spawned a wallet program at {} for {}",
-    hex::encode(address),
+    "spawned a wallet program at {address} for {}",
     hex::encode(args.owner.0),
   );
 
   // send some coins
-  let context = AthenaContext::new(ADDRESS_ALICE, ADDRESS_BOB, 0);
+  let address_bob = Address([0xBB; 24]);
+  let context = AthenaContext::new(ADDRESS_ALICE, address_bob, 0);
 
   let mut stdin = AthenaStdin::new();
   let wallet = host
@@ -89,8 +89,8 @@ fn main() {
   println!(
     "sending {} coins {} -> {}",
     args.amount,
-    hex::encode(context.address()),
-    hex::encode(args.recipient),
+    context.address(),
+    args.recipient,
   );
   // calculate method selector
   let method_selector = MethodSelector::from("athexp_spend");
@@ -146,7 +146,7 @@ mod tests {
 
     let mut host = MockHost::new_with_context(
       HostStaticContext::new(ADDRESS_ALICE, 0, ADDRESS_ALICE),
-      HostDynamicContext::new([0u8; 24], ADDRESS_ALICE),
+      HostDynamicContext::new(Address::default(), ADDRESS_ALICE),
     );
     let address = super::spawn(&mut host, &Pubkey::default()).unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
 
     let address: Address = result.read();
     let template = host.template(&address);
-    assert_eq!(template, Some(&code));
+    assert_eq!(*template.unwrap(), code);
   }
 
   #[test]
@@ -180,7 +180,7 @@ mod tests {
 
     let mut host = MockHost::new_with_context(
       HostStaticContext::new(ADDRESS_ALICE, 0, ADDRESS_ALICE),
-      HostDynamicContext::new([0u8; 24], ADDRESS_ALICE),
+      HostDynamicContext::new(Address::default(), ADDRESS_ALICE),
     );
 
     let signing_key = SigningKey::generate(&mut OsRng);
@@ -237,7 +237,7 @@ mod tests {
 
     let mut host = MockHost::new_with_context(
       HostStaticContext::new(ADDRESS_ALICE, 0, ADDRESS_ALICE),
-      HostDynamicContext::new([0u8; 24], ADDRESS_ALICE),
+      HostDynamicContext::new(Address::default(), ADDRESS_ALICE),
     );
 
     let signing_key = SigningKey::generate(&mut OsRng);
@@ -323,7 +323,7 @@ mod tests {
 
     let mut host = MockHost::new_with_context(
       HostStaticContext::new(ADDRESS_ALICE, 0, ADDRESS_ALICE),
-      HostDynamicContext::new([0u8; 24], ADDRESS_ALICE),
+      HostDynamicContext::new(Address::default(), ADDRESS_ALICE),
     );
 
     let address = super::spawn(&mut host, &Pubkey::default()).unwrap();

--- a/ffi/athcon/bindings/rust/athcon-client/tests/integration_tests.rs
+++ b/ffi/athcon/bindings/rust/athcon-client/tests/integration_tests.rs
@@ -8,7 +8,7 @@ use athcon_client::{
 };
 use athcon_vm::{MessageKind, Revision, StatusCode, StorageStatus};
 use athena_interface::payload::ExecutionPayload;
-use athena_interface::ADDRESS_ALICE;
+const ADDRESS_ALICE: Address = [0xAAu8; 24];
 
 const CONTRACT_CODE: &[u8] =
   include_bytes!("../../../../../../tests/recursive_call/elf/recursive-call-test");

--- a/ffi/athcon/bindings/rust/athcon-vm/src/encode_tx.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/encode_tx.rs
@@ -43,7 +43,7 @@ unsafe extern "C" fn athcon_encode_tx_spend(
     return std::ptr::null_mut();
   }
   let recipient = unsafe { &(*recipient).bytes };
-  let payload = encode_spend(&Address(*recipient), amount);
+  let payload = encode_spend(&Address::from(*recipient), amount);
 
   let (ptr, size) = crate::allocate_output_data(payload);
   Box::into_raw(Box::new(ffi::athcon_bytes { ptr, size }))
@@ -76,10 +76,16 @@ mod tests {
 
   #[test]
   fn encoding_spend_tx() {
-    let address = Address([0x1C; 24]);
+    let address = Address::from([0x1C; 24]);
     let amount = 781237;
-    let encoded_bytes =
-      unsafe { athcon_encode_tx_spend(&ffi::athcon_address { bytes: address.0 }, amount) };
+    let encoded_bytes = unsafe {
+      athcon_encode_tx_spend(
+        &ffi::athcon_address {
+          bytes: address.into(),
+        },
+        amount,
+      )
+    };
 
     let mut encoded_slice = unsafe { (*encoded_bytes).as_slice() };
     let tx = Payload::decode(&mut encoded_slice).unwrap();

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -78,26 +78,6 @@ impl From<Revision> for RevisionWrapper {
   }
 }
 
-struct AddressWrapper(Address);
-
-impl From<ffi::athcon_address> for AddressWrapper {
-  fn from(address: ffi::athcon_address) -> Self {
-    AddressWrapper(address.bytes)
-  }
-}
-
-impl From<AddressWrapper> for Address {
-  fn from(address: AddressWrapper) -> Self {
-    address.0
-  }
-}
-
-impl From<AddressWrapper> for ffi::athcon_address {
-  fn from(address: AddressWrapper) -> Self {
-    ffi::athcon_address { bytes: address.0 }
-  }
-}
-
 struct Bytes32Wrapper(Bytes32);
 
 impl From<Bytes32Wrapper> for ffi::athcon_bytes32 {
@@ -151,8 +131,8 @@ impl From<ffi::athcon_message> for AthenaMessageWrapper {
       kind: kind.0,
       depth: u32::try_from(item.depth).expect("Depth value out of range"),
       gas: u32::try_from(item.gas).expect("Gas value out of range"),
-      recipient: AddressWrapper::from(item.recipient).into(),
-      sender: AddressWrapper::from(item.sender).into(),
+      recipient: Address(item.recipient.bytes),
+      sender: Address(item.sender.bytes),
       input_data,
       value: item.value,
       code,
@@ -174,8 +154,12 @@ impl From<AthenaMessageWrapper> for AthconExecutionMessage {
       kind,
       item.0.depth as i32,
       item.0.gas as i64,
-      AddressWrapper(item.0.recipient).into(),
-      AddressWrapper(item.0.sender).into(),
+      ffi::athcon_address {
+        bytes: item.0.recipient.0,
+      },
+      ffi::athcon_address {
+        bytes: item.0.sender.0,
+      },
       item.0.input_data.as_deref(),
       item.0.value,
       code,
@@ -190,8 +174,8 @@ impl From<&AthconExecutionMessage> for AthenaMessageWrapper {
       kind: kind.0,
       depth: u32::try_from(item.depth()).expect("Depth value out of range"),
       gas: u32::try_from(item.gas()).expect("Gas value out of range"),
-      recipient: item.recipient().bytes,
-      sender: item.sender().bytes,
+      recipient: Address(item.recipient().bytes),
+      sender: Address(item.sender().bytes),
       input_data: item.input().cloned(),
       value: item.value(),
       code: item.code().cloned().unwrap_or_default(),
@@ -357,7 +341,7 @@ impl From<TransactionContextWrapper> for TransactionContext {
     let tx_context = context.0;
     TransactionContext {
       gas_price: tx_context.tx_gas_price,
-      origin: AddressWrapper::from(tx_context.tx_origin).into(),
+      origin: Address(tx_context.tx_origin.bytes),
       block_height: tx_context.block_height,
       block_timestamp: tx_context.block_timestamp,
       block_gas_limit: tx_context.block_gas_limit,
@@ -380,21 +364,26 @@ impl HostInterface for WrappedHostInterface<'_> {
   fn get_storage(&self, addr: &Address, key: &Bytes32) -> Bytes32 {
     let value_wrapper: Bytes32Wrapper = self
       .context
-      .get_storage(&AddressWrapper(*addr).into(), &Bytes32Wrapper(*key).into())
+      .get_storage(
+        &ffi::athcon_address { bytes: addr.0 },
+        &Bytes32Wrapper(*key).into(),
+      )
       .into();
     value_wrapper.into()
   }
 
   fn set_storage(&mut self, addr: &Address, key: &Bytes32, value: &Bytes32) -> StorageStatus {
     convert_storage_status(self.context.set_storage(
-      &AddressWrapper(*addr).into(),
+      &ffi::athcon_address { bytes: addr.0 },
       &Bytes32Wrapper(*key).into(),
       &Bytes32Wrapper(*value).into(),
     ))
   }
 
   fn get_balance(&self, addr: &Address) -> Balance {
-    self.context.get_balance(&AddressWrapper(*addr).into())
+    self
+      .context
+      .get_balance(&ffi::athcon_address { bytes: addr.0 })
   }
 
   fn call(&mut self, msg: AthenaMessage) -> ExecutionResult {
@@ -405,10 +394,10 @@ impl HostInterface for WrappedHostInterface<'_> {
   }
 
   fn spawn(&mut self, blob: Vec<u8>) -> Address {
-    AddressWrapper::from(self.context.spawn(&blob)).into()
+    Address(self.context.spawn(&blob).bytes)
   }
 
   fn deploy(&mut self, code: Vec<u8>) -> Result<Address, Box<dyn Error>> {
-    Ok(AddressWrapper::from(self.context.deploy(&code)).into())
+    Ok(Address(self.context.deploy(&code).bytes))
   }
 }

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -131,8 +131,8 @@ impl From<ffi::athcon_message> for AthenaMessageWrapper {
       kind: kind.0,
       depth: u32::try_from(item.depth).expect("Depth value out of range"),
       gas: u32::try_from(item.gas).expect("Gas value out of range"),
-      recipient: Address(item.recipient.bytes),
-      sender: Address(item.sender.bytes),
+      recipient: Address::from(item.recipient.bytes),
+      sender: Address::from(item.sender.bytes),
       input_data,
       value: item.value,
       code,
@@ -155,10 +155,10 @@ impl From<AthenaMessageWrapper> for AthconExecutionMessage {
       item.0.depth as i32,
       item.0.gas as i64,
       ffi::athcon_address {
-        bytes: item.0.recipient.0,
+        bytes: item.0.recipient.into(),
       },
       ffi::athcon_address {
-        bytes: item.0.sender.0,
+        bytes: item.0.sender.into(),
       },
       item.0.input_data.as_deref(),
       item.0.value,
@@ -174,8 +174,8 @@ impl From<&AthconExecutionMessage> for AthenaMessageWrapper {
       kind: kind.0,
       depth: u32::try_from(item.depth()).expect("Depth value out of range"),
       gas: u32::try_from(item.gas()).expect("Gas value out of range"),
-      recipient: Address(item.recipient().bytes),
-      sender: Address(item.sender().bytes),
+      recipient: Address::from(item.recipient().bytes),
+      sender: Address::from(item.sender().bytes),
       input_data: item.input().cloned(),
       value: item.value(),
       code: item.code().cloned().unwrap_or_default(),
@@ -341,7 +341,7 @@ impl From<TransactionContextWrapper> for TransactionContext {
     let tx_context = context.0;
     TransactionContext {
       gas_price: tx_context.tx_gas_price,
-      origin: Address(tx_context.tx_origin.bytes),
+      origin: Address::from(tx_context.tx_origin.bytes),
       block_height: tx_context.block_height,
       block_timestamp: tx_context.block_timestamp,
       block_gas_limit: tx_context.block_gas_limit,
@@ -365,7 +365,7 @@ impl HostInterface for WrappedHostInterface<'_> {
     let value_wrapper: Bytes32Wrapper = self
       .context
       .get_storage(
-        &ffi::athcon_address { bytes: addr.0 },
+        &ffi::athcon_address { bytes: addr.into() },
         &Bytes32Wrapper(*key).into(),
       )
       .into();
@@ -374,7 +374,7 @@ impl HostInterface for WrappedHostInterface<'_> {
 
   fn set_storage(&mut self, addr: &Address, key: &Bytes32, value: &Bytes32) -> StorageStatus {
     convert_storage_status(self.context.set_storage(
-      &ffi::athcon_address { bytes: addr.0 },
+      &ffi::athcon_address { bytes: addr.into() },
       &Bytes32Wrapper(*key).into(),
       &Bytes32Wrapper(*value).into(),
     ))
@@ -383,7 +383,7 @@ impl HostInterface for WrappedHostInterface<'_> {
   fn get_balance(&self, addr: &Address) -> Balance {
     self
       .context
-      .get_balance(&ffi::athcon_address { bytes: addr.0 })
+      .get_balance(&ffi::athcon_address { bytes: addr.into() })
   }
 
   fn call(&mut self, msg: AthenaMessage) -> ExecutionResult {
@@ -394,10 +394,10 @@ impl HostInterface for WrappedHostInterface<'_> {
   }
 
   fn spawn(&mut self, blob: Vec<u8>) -> Address {
-    Address(self.context.spawn(&blob).bytes)
+    Address::from(self.context.spawn(&blob).bytes)
   }
 
   fn deploy(&mut self, code: Vec<u8>) -> Result<Address, Box<dyn Error>> {
-    Ok(Address(self.context.deploy(&code).bytes))
+    Ok(Address::from(self.context.deploy(&code).bytes))
   }
 }

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -12,5 +12,6 @@ blake3 = "1.5.3"
 bytemuck = "1.19.0"
 hex = "0.4.3"
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
+serde = { version = "1.0.160", features = ["derive"] }
 tracing = "0.1.40"
 mockall = "0.13.0"

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -54,7 +54,31 @@ impl std::fmt::Display for MethodSelector {
   Deserialize,
   Serialize,
 )]
-pub struct Address(pub [u8; ADDRESS_LENGTH]);
+pub struct Address([u8; ADDRESS_LENGTH]);
+
+impl From<&Address> for [u8; ADDRESS_LENGTH] {
+  fn from(value: &Address) -> Self {
+    value.0
+  }
+}
+
+impl From<Address> for [u8; ADDRESS_LENGTH] {
+  fn from(value: Address) -> Self {
+    value.0
+  }
+}
+
+impl From<[u8; ADDRESS_LENGTH]> for Address {
+  fn from(value: [u8; ADDRESS_LENGTH]) -> Self {
+    Address(value)
+  }
+}
+
+impl AsRef<[u8; ADDRESS_LENGTH]> for Address {
+  fn as_ref(&self) -> &[u8; ADDRESS_LENGTH] {
+    &self.0
+  }
+}
 
 impl std::fmt::Display for Address {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -9,13 +9,13 @@ pub use context::*;
 use blake3::Hasher;
 pub use parity_scale_codec::{Decode, Encode};
 use payload::ExecutionPayload;
+use serde::{Deserialize, Serialize};
 
 use std::{collections::BTreeMap, convert::TryFrom, error::Error, fmt};
 
 pub const ADDRESS_LENGTH: usize = 24;
 pub const BYTES32_LENGTH: usize = 32;
 pub const METHOD_SELECTOR_LENGTH: usize = 4;
-pub type Address = [u8; ADDRESS_LENGTH];
 pub type Balance = u64;
 pub type Bytes32 = [u8; BYTES32_LENGTH];
 pub type Bytes = [u8];
@@ -40,23 +40,25 @@ impl std::fmt::Display for MethodSelector {
   }
 }
 
-pub struct AddressWrapper(Address);
+#[derive(
+  Debug,
+  Default,
+  Copy,
+  Clone,
+  PartialOrd,
+  Ord,
+  PartialEq,
+  Eq,
+  Decode,
+  Encode,
+  Deserialize,
+  Serialize,
+)]
+pub struct Address(pub [u8; ADDRESS_LENGTH]);
 
-impl From<Vec<u32>> for AddressWrapper {
-  fn from(value: Vec<u32>) -> Self {
-    assert!(value.len() == ADDRESS_LENGTH / 4, "Invalid address length");
-    let mut bytes = [0u8; ADDRESS_LENGTH];
-    for (i, word) in value.iter().enumerate() {
-      let value_bytes = word.to_le_bytes();
-      bytes[i * 4..(i + 1) * 4].copy_from_slice(&value_bytes);
-    }
-    AddressWrapper(bytes)
-  }
-}
-
-impl From<AddressWrapper> for Address {
-  fn from(value: AddressWrapper) -> Address {
-    value.0
+impl std::fmt::Display for Address {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", hex::encode(self.0))
   }
 }
 
@@ -89,14 +91,6 @@ impl From<Bytes32Wrapper> for Vec<u32> {
 impl From<Bytes32Wrapper> for Bytes32 {
   fn from(value: Bytes32Wrapper) -> Bytes32 {
     value.0
-  }
-}
-
-impl From<Address> for Bytes32Wrapper {
-  fn from(value: Address) -> Bytes32Wrapper {
-    let mut bytes = [0u8; 32];
-    bytes[..24].copy_from_slice(&value);
-    Bytes32Wrapper(bytes)
   }
 }
 
@@ -337,11 +331,11 @@ pub fn calculate_address(
 ) -> Address {
   // calculate address by hashing the template, blob, principal, and nonce
   let mut hasher = Hasher::new();
-  hasher.update(template);
+  hasher.update(&template.0);
   hasher.update(blob);
-  hasher.update(principal);
+  hasher.update(&principal.0);
   hasher.update(&nonce.to_le_bytes());
-  hasher.finalize().as_bytes()[..24].try_into().unwrap()
+  Address(hasher.finalize().as_bytes()[..24].try_into().unwrap())
 }
 // Stores some of the context that a running host would store to keep
 // track of what's going on in the VM execution
@@ -496,9 +490,8 @@ impl<'a> MockHost<'a> {
   }
 }
 
-pub const ADDRESS_ALICE: Address = [1u8; ADDRESS_LENGTH];
-pub const ADDRESS_BOB: Address = [2u8; ADDRESS_LENGTH];
-pub const ADDRESS_CHARLIE: Address = [3u8; ADDRESS_LENGTH];
+pub const ADDRESS_ALICE: Address = Address([1u8; ADDRESS_LENGTH]);
+pub const ADDRESS_CHARLIE: Address = Address([3u8; ADDRESS_LENGTH]);
 // "sentinel value" useful for testing: 0xc0ffee
 // also useful as a morning wake up!
 pub const STORAGE_KEY: Bytes32 = [
@@ -650,7 +643,7 @@ impl HostInterface for MockHost<'_> {
     // template_address := HASH(template_code)
     let hash = blake3::hash(&code);
     let hash_bytes = hash.as_bytes().as_slice();
-    let address = Address::try_from(&hash_bytes[..ADDRESS_LENGTH]).unwrap();
+    let address = Address(hash_bytes[..ADDRESS_LENGTH].try_into().unwrap());
 
     if self.templates.contains_key(&address) {
       return Err("template already exists".into());
@@ -698,7 +691,7 @@ mod tests {
   #[test]
   fn test_get_storage() {
     let mut host = MockHost::new();
-    let address = [8; 24];
+    let address = Address([8; 24]);
     let key = [1; 32];
     let value = [2; 32];
     assert_eq!(
@@ -712,7 +705,7 @@ mod tests {
   #[test]
   fn test_get_balance() {
     let host = MockHost::new();
-    let address = [8; 24];
+    let address = Address([8; 24]);
     let balance = host.get_balance(&address);
     assert_eq!(balance, 0);
   }
@@ -802,11 +795,12 @@ mod tests {
     assert_eq!(host.get_balance(&ADDRESS_CHARLIE), 100);
 
     // bob is not callable (which means coins also cannot be sent, even if we have them)
+    let address_bob = Address([0xBB; 24]);
     let msg = AthenaMessage::new(
       MessageKind::Call,
       0,
       1000,
-      ADDRESS_BOB,
+      address_bob,
       ADDRESS_ALICE,
       None,
       100,
@@ -815,7 +809,7 @@ mod tests {
     let res = host.call(msg);
     assert_eq!(res.status_code, StatusCode::Failure);
     assert_eq!(host.get_balance(&ADDRESS_ALICE), 10000 - 100);
-    assert_eq!(host.get_balance(&ADDRESS_BOB), 0);
+    assert_eq!(host.get_balance(&address_bob), 0);
   }
 
   #[test]
@@ -823,7 +817,7 @@ mod tests {
     let mut host = MockHost::new();
     let blob = vec![1, 2, 3, 4];
     let address = host.spawn_program(&ADDRESS_ALICE, blob.clone(), &ADDRESS_ALICE, 0);
-    assert_eq!(host.programs.get(&address), Some(&blob));
+    assert_eq!(host.get_program(&address), Some(&blob));
   }
 
   #[test]
@@ -831,7 +825,7 @@ mod tests {
     let mut host = MockHost::new();
     let blob = vec![1, 2, 3, 4];
     let address = host.deploy(blob.clone());
-    assert_eq!(host.template(&address.unwrap()), Some(&blob));
+    assert_eq!(*host.template(&address.unwrap()).unwrap(), blob);
 
     // deploying again should fail
     let address = host.deploy(blob.clone());

--- a/tests/entrypoint/Cargo.lock
+++ b/tests/entrypoint/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/tests/panic/Cargo.lock
+++ b/tests/panic/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "mockall",
  "parity-scale-codec",
+ "serde",
  "tracing",
 ]
 

--- a/tests/recursive_call/Cargo.toml
+++ b/tests/recursive_call/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+athena-interface = {path = "../../interface"}
 athena-vm = { path = "../../vm/entrypoint", features = ["rv32e"] }
 athena-vm-sdk = { path = "../../vm/sdk" }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"
 athena-sdk = { path = "../../sdk" }
-athena-interface = { path = "../../interface" }
 athena-runner = { path = "../../runner" }

--- a/tests/recursive_call/src/main.rs
+++ b/tests/recursive_call/src/main.rs
@@ -3,14 +3,15 @@
 #[cfg(target_os = "zkvm")]
 athena_vm::entrypoint!(main);
 
+use athena_interface::Address;
 use athena_vm_sdk::call;
 
 fn return_value(value: u32) {
   athena_vm::io::write::<u32>(&value);
 }
 
-fn recursive_call(address: [u8; 24], value: u32) -> u32 {
-  let mut input = address.to_vec();
+fn recursive_call(address: Address, value: u32) -> u32 {
+  let mut input = address.0.to_vec();
   input.extend_from_slice(&value.to_le_bytes());
   let output = call(address, Some(input), None, 0);
   u32::from_le_bytes(output.as_slice().try_into().unwrap())
@@ -20,7 +21,7 @@ fn main() {
   // Read an input to the program.
   //
   // Behind the scenes, this compiles down to a custom system call which handles reading inputs.
-  let (address, n) = athena_vm::io::read::<([u8; 24], u32)>();
+  let (address, n) = athena_vm::io::read::<(Address, u32)>();
   // Base case
   if n <= 1 {
     return_value(n);

--- a/tests/recursive_call/src/main.rs
+++ b/tests/recursive_call/src/main.rs
@@ -11,7 +11,7 @@ fn return_value(value: u32) {
 }
 
 fn recursive_call(address: Address, value: u32) -> u32 {
-  let mut input = address.0.to_vec();
+  let mut input = address.as_ref().to_vec();
   input.extend_from_slice(&value.to_le_bytes());
   let output = call(address, Some(input), None, 0);
   u32::from_le_bytes(output.as_slice().try_into().unwrap())

--- a/tests/recursive_call/tests/test.rs
+++ b/tests/recursive_call/tests/test.rs
@@ -10,7 +10,7 @@ fn test() {
   let mut stdin = AthenaStdin::new();
   let vm = AthenaVm::new();
   let mut host = MockHost::new_with_vm(&vm);
-  let template_address = Address([0x77; 24]);
+  let template_address = Address::from([0x77; 24]);
   stdin.write(&(template_address, 6u32));
   host.deploy_code(template_address, elf.to_vec());
 

--- a/tests/recursive_call/tests/test.rs
+++ b/tests/recursive_call/tests/test.rs
@@ -1,4 +1,4 @@
-use athena_interface::{AthenaContext, MockHost};
+use athena_interface::{Address, AthenaContext, MockHost};
 use athena_runner::AthenaVm;
 use athena_sdk::{AthenaStdin, ExecutionClient};
 
@@ -10,7 +10,7 @@ fn test() {
   let mut stdin = AthenaStdin::new();
   let vm = AthenaVm::new();
   let mut host = MockHost::new_with_vm(&vm);
-  let template_address = [0x77; 24];
+  let template_address = Address([0x77; 24]);
   stdin.write(&(template_address, 6u32));
   host.deploy_code(template_address, elf.to_vec());
 

--- a/vm/entrypoint/src/helpers/mod.rs
+++ b/vm/entrypoint/src/helpers/mod.rs
@@ -1,19 +1,7 @@
-use athena_interface::{Address, Balance, Bytes32, Bytes32Wrapper};
+use athena_interface::Bytes32;
 use bytemuck::cast;
 
 // Simple helper functions for smart contracts
-
-pub fn address_to_bytes32(address: Address) -> Bytes32 {
-  Bytes32Wrapper::from(address).into()
-}
-
-pub fn address_to_32bit_words(address: Address) -> [u32; 6] {
-  cast::<[u8; 24], [u32; 6]>(address)
-}
-
-pub fn balance_to_32bit_words(balance: Balance) -> [u32; 2] {
-  cast::<[u8; 8], [u32; 2]>(balance.to_le_bytes())
-}
 
 pub fn bytes32_to_32bit_words(bytes32: Bytes32) -> [u32; 8] {
   cast::<[u8; 32], [u32; 8]>(bytes32)

--- a/vm/sdk/src/wallet.rs
+++ b/vm/sdk/src/wallet.rs
@@ -52,7 +52,7 @@ mod tests {
   #[test]
   fn encode_decode_spend() {
     let args = SpendArguments {
-      recipient: Address([22u8; 24]),
+      recipient: Address::from([22u8; 24]),
       amount: 800,
     };
     let encoded = super::encode_spend(&args.recipient, args.amount);

--- a/vm/sdk/src/wallet.rs
+++ b/vm/sdk/src/wallet.rs
@@ -44,7 +44,7 @@ pub fn encode_spawn(pubkey: &Pubkey) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-  use athena_interface::{payload::Payload, MethodSelector};
+  use athena_interface::{payload::Payload, Address, MethodSelector};
   use parity_scale_codec::{Decode, IoReader};
 
   use super::SpendArguments;
@@ -52,7 +52,7 @@ mod tests {
   #[test]
   fn encode_decode_spend() {
     let args = SpendArguments {
-      recipient: [22u8; 24],
+      recipient: Address([22u8; 24]),
       amount: 800,
     };
     let encoded = super::encode_spend(&args.recipient, args.amount);


### PR DESCRIPTION
Change `athena_interface::Address` to be a newtype wrapping a `[u8;24]` instead of a type alias. 

Benefits:
- stronger type safety,
- allows for implementing foreign traits (like `std::fmt::Display`, `From`)
- removed some unnecessary wrapper code (`AddressWrapper`)