### PR TITLE
New workaround for macOS linker issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ members = [
   "runner",
   "sdk",
   "tests/host",
-  "tests/recursive_call",
   "vm/declare",
   "vm/entrypoint",
   "vm/lib",

--- a/vm/sdk/src/lib.rs
+++ b/vm/sdk/src/lib.rs
@@ -7,11 +7,10 @@ pub mod precompiles;
 pub mod wallet;
 pub use wallet::*;
 
-mod call;
-pub use call::call;
-
 cfg_if! {
   if #[cfg(target_os = "zkvm")] {
+    mod call;
+    pub use call::call;
     mod spawn;
     pub use spawn::spawn;
     mod deploy;


### PR DESCRIPTION
Fixes #215

I don't know why, but it works. I isolated the original issue to this change:

https://github.com/athenavm/athena/pull/145/commits/d540a820aacf7010992dae67ff3827064e6a777d#diff-1a9c17ef3b6a70254124f54ee4a8f2ceb17a3a7f8ed9570473a03e3246860ba4

Undoing this seems to work