### PR TITLE
don't export `sys_alloc_aligned`

### DIFF
--- a/vm/entrypoint/src/syscalls/memory.rs
+++ b/vm/entrypoint/src/syscalls/memory.rs
@@ -16,9 +16,10 @@
 // Note: We inherit this constraint from SP1, and I don't see a reason to remove it.
 const MAX_MEMORY: usize = 0x78000000;
 
-#[allow(clippy::missing_safety_doc)]
-#[no_mangle]
-pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8 {
+/// # Safety
+/// - `align` must not be zero and must be a power of 2
+/// - `bytes` must not be zero
+pub unsafe fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8 {
   extern "C" {
     // https://lld.llvm.org/ELF/linker_script.html#sections-command
     static _end: u8;

--- a/vm/lib/src/lib.rs
+++ b/vm/lib/src/lib.rs
@@ -9,5 +9,4 @@ extern "C" {
   pub fn syscall_read(fd: u32, read_buf: *mut u8, nbytes: usize);
   pub fn syscall_hint_len() -> usize;
   pub fn syscall_hint_read(ptr: *mut u8, len: usize);
-  pub fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u8;
 }


### PR DESCRIPTION
Fixes #215, Closes #217 

The problem described in #215 happens because the `sys_alloc_aligned` function is present in the athena VM library - in the host code, not in a guest program. It makes no sense to have it there as it is only needed by guest programs running in a VM. This PR removes the `export "C"` so the function is not exported and is not included in the VM library.

Before:
```
❯ objdump target/release/libathena_vmlib.so -d | rg 'sys_alloc_aligned>'
00000000001584a0 <sys_alloc_aligned>:
```

After:
```
❯ objdump target/release/libathena_vmlib.so -d | rg 'sys_alloc_aligned>'
```

Note: the same statement is true for other exported system calls. They are also wrongly included in the VM library. However, because of #117, it is not possible to remove them easily without refactoring. There is a weird dependency cycle:
- `athena-vm` (vm/entrypoint) depends on `athena-lib` (vm/lib)
- `athena-lib` calls functions from `athena-vm`

This dependency cycle is "fixed" by using exported functions, which are resolved at link time.