### PR TITLE
release the lib on windows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,14 @@ jobs:
 
   test-go:
     name: Test (Go)
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - [runs-on, runner=8cpu-linux-arm64, "run-id=${{ github.run_id }}"]
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.runner }}
     needs: build-binaries
     steps:
       - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,13 +177,10 @@ jobs:
             -C $GITHUB_WORKSPACE/ffi/athcon include
             echo "file_name_2=athena_vmlib_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
           else
-            cd ./target/${TARGET}/release
-            7z a -tzip "cargo_athena_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" cargo-athena.exe
-            mv "cargo_athena_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
+            7z a -tzip "cargo_athena_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ./target/${TARGET}/release/cargo-athena.exe
             echo "file_name_1=cargo_athena_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> $GITHUB_OUTPUT
-            # TODO: add athcon headers
-            7z a -tzip "athena_vmlib_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" libathena_vmlib.dll
-            mv "athena_vmlib_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
+            7z a -tzip "athena_vmlib_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ./target/${TARGET}/release/athena_vmlib.dll
+            7z a "athena_vmlib_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ./ffi/athcon/include
             echo "file_name_2=athena_vmlib_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,10 @@ jobs:
             target: aarch64-apple-darwin
             platform: darwin
             arch: arm64
-          # - runner: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          #   platform: win32
-          #   arch: amd64
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: win32
+            arch: amd64
     steps:
       - uses: actions/checkout@v4
 

--- a/cli/src/commands/install_toolchain.rs
+++ b/cli/src/commands/install_toolchain.rs
@@ -176,14 +176,17 @@ impl InstallToolchainCmd {
     println!("Successfully linked toolchain to rustup.");
 
     // Ensure permissions.
-    let bin_dir = new_toolchain_dir.join("bin");
-    let rustlib_bin_dir = new_toolchain_dir.join(format!("lib/rustlib/{}/bin", target));
-    for entry in fs::read_dir(bin_dir)?.chain(fs::read_dir(rustlib_bin_dir)?) {
-      let entry = entry?;
-      if entry.path().is_file() {
-        let mut perms = entry.metadata()?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(entry.path(), perms)?;
+    #[cfg(target_family = "unix")]
+    {
+      let bin_dir = new_toolchain_dir.join("bin");
+      let rustlib_bin_dir = new_toolchain_dir.join(format!("lib/rustlib/{}/bin", target));
+      for entry in fs::read_dir(bin_dir)?.chain(fs::read_dir(rustlib_bin_dir)?) {
+        let entry = entry?;
+        if entry.path().is_file() {
+          let mut perms = entry.metadata()?.permissions();
+          perms.set_mode(0o755);
+          fs::set_permissions(entry.path(), perms)?;
+        }
       }
     }
 

--- a/examples/wallet/program/src/main.rs
+++ b/examples/wallet/program/src/main.rs
@@ -6,7 +6,8 @@ extern crate alloc;
 use athena_interface::Address;
 use athena_vm::entrypoint;
 use athena_vm_declare::{callable, template};
-use athena_vm_sdk::{call, spawn, Pubkey, SpendArguments, VerifiableTemplate, WalletProgram};
+use athena_vm_sdk::wallet::{SpendArguments, WalletProgram};
+use athena_vm_sdk::{call, spawn, Pubkey, VerifiableTemplate};
 use parity_scale_codec::{Decode, Encode};
 
 #[derive(Debug, Encode, Decode)]

--- a/examples/wallet/script/src/bin/execute.rs
+++ b/examples/wallet/script/src/bin/execute.rs
@@ -12,7 +12,7 @@ use athena_interface::{
   MethodSelector, MockHost, ADDRESS_ALICE, ADDRESS_CHARLIE,
 };
 use athena_sdk::{AthenaStdin, ExecutionClient};
-use athena_vm_sdk::{Pubkey, SpendArguments};
+use athena_vm_sdk::{wallet::SpendArguments, Pubkey};
 use clap::Parser;
 
 /// The ELF (executable and linkable format) file for the Athena RISC-V VM.
@@ -333,7 +333,9 @@ mod tests {
 
     let mut stdin = AthenaStdin::new();
     stdin.write_vec(wallet_state.clone());
-    stdin.write_vec(athena_vm_sdk::encode_spend_inner(&recipient, amount));
+    stdin.write_vec(athena_vm_sdk::wallet::encode_spend_inner(
+      &recipient, amount,
+    ));
 
     let selector = MethodSelector::from("athexp_max_spend");
     let result = ExecutionClient::new().execute_function(

--- a/ffi/athcon/bindings/go/athcon.go
+++ b/ffi/athcon/bindings/go/athcon.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/athenavm/athena/ffi/athcon/bindings/go/internal/load"
 	"github.com/ebitengine/purego"
 )
 
@@ -82,7 +83,7 @@ type Library struct {
 }
 
 func LoadLibrary(path string) (*Library, error) {
-	libHandle, err := purego.Dlopen(path, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+	libHandle, err := load.LoadLibrary(path)
 	if err != nil {
 		return nil, fmt.Errorf("loading library: %v", err)
 	}
@@ -102,8 +103,8 @@ func LoadLibrary(path string) (*Library, error) {
 	return lib, nil
 }
 
-func (l *Library) Close() {
-	purego.Dlclose(l.libHandle)
+func (l *Library) Close() error {
+	return load.CloseLibrary(l.libHandle)
 }
 
 type VM struct {
@@ -149,9 +150,9 @@ func LoadAndConfigure(filename string, config map[string]string) (vm *VM, err er
 	return vm, err
 }
 
-func (vm *VM) Destroy() {
+func (vm *VM) Destroy() error {
 	C.athcon_destroy(vm.handle)
-	vm.Lib.Close()
+	return vm.Lib.Close()
 }
 
 func (vm *VM) Name() string {

--- a/ffi/athcon/bindings/go/athcon_test.go
+++ b/ffi/athcon/bindings/go/athcon_test.go
@@ -1,5 +1,5 @@
 //go:generate cargo build --release --manifest-path ../../../vmlib/Cargo.toml
-//go:generate cp ../../../../target/release/libathena_vmlib.so ./libathenavmwrapper.so
+//go:generate go run ./scripts/copy_lib.go
 
 package athcon
 

--- a/ffi/athcon/bindings/go/host_test.go
+++ b/ffi/athcon/bindings/go/host_test.go
@@ -119,7 +119,7 @@ func randomAddress() Address {
 // TestGetBalance tests the GetBalance() host function. It's a minimal test that
 // only executes a few instructions.
 func TestGetBalance(t *testing.T) {
-	vm, _ := Load(modulePath)
+	vm, _ := Load(libPath(t))
 	defer vm.Destroy()
 
 	host := newHost(vm)
@@ -135,7 +135,7 @@ func TestGetBalance(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
-	vm, _ := Load(modulePath)
+	vm, _ := Load(libPath(t))
 	defer vm.Destroy()
 
 	host := newHost(vm)
@@ -160,7 +160,7 @@ func TestCall(t *testing.T) {
 }
 
 func TestSpawn(t *testing.T) {
-	vm, _ := Load(modulePath)
+	vm, _ := Load(libPath(t))
 	defer vm.Destroy()
 
 	host := newHost(vm)
@@ -178,7 +178,7 @@ func TestSpawn(t *testing.T) {
 }
 
 func TestSpend(t *testing.T) {
-	vm, _ := Load(modulePath)
+	vm, _ := Load(libPath(t))
 	defer vm.Destroy()
 
 	host := newHost(vm)
@@ -213,7 +213,7 @@ func TestSpend(t *testing.T) {
 }
 
 func TestVerify(t *testing.T) {
-	vm, _ := Load(modulePath)
+	vm, _ := Load(libPath(t))
 	defer vm.Destroy()
 
 	host := newHost(vm)

--- a/ffi/athcon/bindings/go/internal/load/load_unix.go
+++ b/ffi/athcon/bindings/go/internal/load/load_unix.go
@@ -1,0 +1,13 @@
+//go:build (darwin || freebsd || linux) && !android && !faketime
+
+package load
+
+import "github.com/ebitengine/purego"
+
+func LoadLibrary(path string) (uintptr, error) {
+	return purego.Dlopen(path, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+}
+
+func CloseLibrary(handle uintptr) error {
+	return purego.Dlclose(handle)
+}

--- a/ffi/athcon/bindings/go/internal/load/load_windows.go
+++ b/ffi/athcon/bindings/go/internal/load/load_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package load
+
+import "syscall"
+
+func LoadLibrary(path string) (uintptr, error) {
+	handle, err := syscall.LoadLibrary(path)
+	return uintptr(handle), err
+}
+
+func CloseLibrary(handle uintptr) error {
+	return syscall.FreeLibrary(syscall.Handle(handle))
+}

--- a/ffi/athcon/bindings/go/scripts/copy_lib.go
+++ b/ffi/athcon/bindings/go/scripts/copy_lib.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func main() {
+	var ext string
+	switch runtime.GOOS {
+	case "linux":
+		ext = "so"
+	case "darwin":
+		ext = "dylib"
+	case "windows":
+		ext = "dll"
+	default:
+		fmt.Printf("Unsupported operating system: %s", runtime.GOOS)
+		os.Exit(1)
+	}
+
+	srcPath := filepath.Join("../../../../target/release", fmt.Sprintf("libathena_vmlib.%s", ext))
+	dstPath := filepath.Join(".", fmt.Sprintf("libathenavmwrapper.%s", ext))
+
+	fmt.Printf("+ Copying %s to %s\n", srcPath, dstPath)
+	input, err := os.ReadFile(srcPath)
+	if err != nil {
+		fmt.Printf("Error reading source file: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = os.WriteFile(dstPath, input, 0644)
+	if err != nil {
+		fmt.Printf("Error writing destination file: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/ffi/athcon/bindings/go/scripts/copy_lib.go
+++ b/ffi/athcon/bindings/go/scripts/copy_lib.go
@@ -3,26 +3,28 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 )
 
 func main() {
-	var ext string
+	var (
+		srcPath string
+		dstPath string
+	)
 	switch runtime.GOOS {
 	case "linux":
-		ext = "so"
+		srcPath = "../../../../target/release/libathena_vmlib.so"
+		dstPath = "libathenavmwrapper.so"
 	case "darwin":
-		ext = "dylib"
+		srcPath = "../../../../target/release/libathena_vmlib.dylib"
+		dstPath = "libathenavmwrapper.dylib"
 	case "windows":
-		ext = "dll"
+		srcPath = "../../../../target/release/athena_vmlib.dll"
+		dstPath = "libathenavmwrapper.dll"
 	default:
 		fmt.Printf("Unsupported operating system: %s", runtime.GOOS)
 		os.Exit(1)
 	}
-
-	srcPath := filepath.Join("../../../../target/release", fmt.Sprintf("libathena_vmlib.%s", ext))
-	dstPath := filepath.Join(".", fmt.Sprintf("libathenavmwrapper.%s", ext))
 
 	fmt.Printf("+ Copying %s to %s\n", srcPath, dstPath)
 	input, err := os.ReadFile(srcPath)

--- a/ffi/athcon/bindings/rust/athcon-vm/Cargo.toml
+++ b/ffi/athcon/bindings/rust/athcon-vm/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 [dependencies]
 athcon-sys = { path = "../athcon-sys" }
 athena-interface = { path = "../../../../../interface" }
-athena-vm-sdk = { path = "../../../../../vm/sdk" }
+athena-vm-sdk = { path = "../../../../../vm/sdk", default-features = false }
 
 [dev-dependencies]
 parity-scale-codec = "3.6.12"

--- a/ffi/athcon/bindings/rust/athcon-vm/src/encode_tx.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/encode_tx.rs
@@ -2,7 +2,8 @@
 
 use athcon_sys as ffi;
 use athena_interface::Address;
-use athena_vm_sdk::{encode_spawn, encode_spend, Pubkey};
+use athena_vm_sdk::wallet::{encode_spawn, encode_spend};
+use athena_vm_sdk::Pubkey;
 
 /// Encode Athena Spawn transaction payload.
 ///
@@ -56,7 +57,7 @@ mod tests {
     payload::{Decode, Payload},
     Address, MethodSelector,
   };
-  use athena_vm_sdk::{Pubkey, SpendArguments};
+  use athena_vm_sdk::{wallet::SpendArguments, Pubkey};
   use parity_scale_codec::IoReader;
 
   use crate::encode_tx::{athcon_encode_tx_spawn, athcon_encode_tx_spend};

--- a/vm/entrypoint/src/lib.rs
+++ b/vm/entrypoint/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate alloc;
 
+#[cfg(target_os = "zkvm")]
 pub mod heap;
+
 pub mod helpers;
 pub mod io;
 pub mod program;

--- a/vm/sdk/Cargo.toml
+++ b/vm/sdk/Cargo.toml
@@ -8,8 +8,12 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-athena-vm = { path = "../entrypoint" }
+athena-vm = { path = "../entrypoint", optional = true }
 athena-interface = { path = "../../interface" }
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
 cfg-if = "1.0.0"
 serde = { version = "1.0", features = ["derive"] }
+
+[features]
+default = ["vm"]
+vm = ["dep:athena-vm"]


### PR DESCRIPTION
Enable testing the Go bindings on all supported targets and release the library for windows. 

A successful pre-release with windows artifacts: https://github.com/athenavm/athena/releases/tag/nightly-70faee4e6d3c2dbf3b6325732ae767b2c9e744e3

The library on windows exhibited linker issues similar to #215. I found that this happens because the code, which is meant for running in the VM (the contents of `athena-vm-sdk` and `athena-vm` crates, specifically the `athena-vm::heap` package which contains the heap allocator for the guest programs) is a dependency of the `athena-vmlib` crate. This dependency was added to add export the encoding functions for the wallet. 

I temporarily (?) resolved this problem by making the `athena-vm` an optional dependency of the `athena-vm-sdk` (enabled by default) to allow the `athena-vmlib` opting out from importing the VM-side code.

Long term, I think we should rethink whether the `athena-vm-sdk` is the right place for the wallet example structures definitions (like `SpendArguments` etc.). I believe this is not the right place and it should be defined in the wallet crate but I didn't want to refactor it in this PR.