### PR TITLE
Initialize deploy callback in Go host interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,16 +1461,15 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athcon-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athcon-sys",
  "athcon-vm",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "athcon-declare"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athcon-vm",
  "heck",
@@ -122,14 +122,14 @@ dependencies = [
 
 [[package]]
 name = "athcon-sys"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bindgen",
 ]
 
 [[package]]
 name = "athcon-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athcon-sys",
  "athena-interface",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "athena-builder"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "athena-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "athena-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-core",
  "athena-helper",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "athena-helper"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-builder",
  "cargo_metadata",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "athena-runner"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athcon-sys",
  "athcon-vm",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "athena-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "athena-core",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-declare"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "athena-vm",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vmlib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athcon-declare",
  "athcon-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["examples"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Lane Rettig <lane@spacemesh.io>"]
 repository = "https://github.com/athenavm/athena"
 homepage = "https://www.athenavm.org/"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,11 +29,11 @@ athena-core = { path = ".", features = ["unittest"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 athena-vm = { path = "../vm/entrypoint" }
 athena-vm-sdk = { path = "../vm/sdk" }
-parity-scale-codec = "3.7.0"
+parity-scale-codec = "3.6.12"
 
 [features]
 debug = []
 unittest = []
 
 [build-dependencies]
-athena-helper = {path = "../helper"}
+athena-helper = { path = "../helper" }

--- a/core/src/runtime/gdbstub.rs
+++ b/core/src/runtime/gdbstub.rs
@@ -21,7 +21,7 @@ use gdbstub::{
 
 use super::{Event, ExecutionError, Register, Runtime};
 
-impl<'h> Target for Runtime<'h> {
+impl Target for Runtime<'_> {
   type Arch = Riscv32e;
 
   type Error = String;
@@ -37,7 +37,7 @@ impl<'h> Target for Runtime<'h> {
   }
 }
 
-impl<'h> Breakpoints for Runtime<'h> {
+impl Breakpoints for Runtime<'_> {
   fn support_sw_breakpoint(
     &mut self,
   ) -> Option<gdbstub::target::ext::breakpoints::SwBreakpointOps<'_, Self>> {
@@ -45,7 +45,7 @@ impl<'h> Breakpoints for Runtime<'h> {
   }
 }
 
-impl<'h> SingleThreadSingleStep for Runtime<'h> {
+impl SingleThreadSingleStep for Runtime<'_> {
   fn step(&mut self, _signal: Option<Signal>) -> Result<(), Self::Error> {
     tracing::trace!("single stepping");
     let _ = self.execute_cycle();
@@ -53,7 +53,7 @@ impl<'h> SingleThreadSingleStep for Runtime<'h> {
   }
 }
 
-impl<'h> SingleThreadResume for Runtime<'h> {
+impl SingleThreadResume for Runtime<'_> {
   fn resume(&mut self, _signal: Option<Signal>) -> Result<(), Self::Error> {
     tracing::trace!("resuming");
     Ok(())
@@ -66,7 +66,7 @@ impl<'h> SingleThreadResume for Runtime<'h> {
   }
 }
 
-impl<'h> SwBreakpoint for Runtime<'h> {
+impl SwBreakpoint for Runtime<'_> {
   fn add_sw_breakpoint(
     &mut self,
     addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
@@ -88,7 +88,7 @@ impl<'h> SwBreakpoint for Runtime<'h> {
   }
 }
 
-impl<'h> SingleThreadBase for Runtime<'h> {
+impl SingleThreadBase for Runtime<'_> {
   fn read_registers(
     &mut self,
     regs: &mut <Self::Arch as gdbstub::arch::Arch>::Registers,
@@ -173,7 +173,7 @@ impl<'h> SingleThreadBase for Runtime<'h> {
   }
 }
 
-impl<'h> SingleRegisterAccess<()> for Runtime<'h> {
+impl SingleRegisterAccess<()> for Runtime<'_> {
   fn read_register(
     &mut self,
     _tid: (),
@@ -223,7 +223,7 @@ struct GdbBlockingEventLoop<'h> {
   _h: std::marker::PhantomData<Runtime<'h>>,
 }
 
-impl<'h> GdbBlockingEventLoop<'h> {
+impl GdbBlockingEventLoop<'_> {
   fn execute_with_poll(
     runtime: &mut Runtime,
     mut poll_incoming_data: impl FnMut() -> bool,

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -80,14 +80,14 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athcon-sys"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "bindgen",
 ]
 
 [[package]]
 name = "athcon-vm"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "athcon-sys",
  "athena-interface",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "athena-builder"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "athena-core"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "athena-helper",
  "athena-interface",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "athena-helper"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "athena-builder",
  "cargo_metadata",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "athena-interface"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "athena-runner"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "athcon-sys",
  "athcon-vm",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "athena-sdk"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "athena-core",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-sdk"
-version = "0.5.3"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "athena-vm",
@@ -290,9 +290,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "afc309ed89476c8957c50fb818f56fe894db857866c3e163335faa91dc34eb85"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -904,9 +904,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mockall"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/examples/fibonacci/program/Cargo.lock
+++ b/examples/fibonacci/program/Cargo.lock
@@ -241,16 +241,15 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
@@ -369,12 +368,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "serde"

--- a/examples/fibonacci/program/Cargo.lock
+++ b/examples/fibonacci/program/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",

--- a/examples/hello_world/program/Cargo.lock
+++ b/examples/hello_world/program/Cargo.lock
@@ -241,16 +241,15 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
@@ -369,12 +368,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "serde"

--- a/examples/hello_world/program/Cargo.lock
+++ b/examples/hello_world/program/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",

--- a/examples/io/program/Cargo.lock
+++ b/examples/io/program/Cargo.lock
@@ -242,16 +242,15 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
@@ -370,12 +369,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "serde"

--- a/examples/io/program/Cargo.lock
+++ b/examples/io/program/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",

--- a/examples/wallet/program/Cargo.lock
+++ b/examples/wallet/program/Cargo.lock
@@ -254,16 +254,15 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
@@ -382,12 +381,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "serde"

--- a/examples/wallet/program/Cargo.lock
+++ b/examples/wallet/program/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-declare"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "athena-vm",

--- a/ffi/athcon/bindings/go/host.go
+++ b/ffi/athcon/bindings/go/host.go
@@ -16,6 +16,7 @@ struct athcon_tx_context getTxContext(void *ctx);
 athcon_bytes32 getBlockHash(void *ctx, long long int number);
 struct athcon_result call(void *ctx, struct athcon_message *msg);
 athcon_address spawn(void *ctx, uint8_t *blob, size_t len);
+athcon_address deploy(void *ctx, uint8_t *blob, size_t len);
 */
 import "C"
 import (
@@ -189,5 +190,6 @@ func newHostInterface() *C.struct_athcon_host_interface {
 		get_block_hash: (C.athcon_get_block_hash_fn)(C.getBlockHash),
 		call:           (C.athcon_call_fn)(C.call),
 		spawn:          (C.athcon_spawn_fn)(C.spawn),
+		deploy:         (C.athcon_deploy_fn)(C.deploy),
 	}
 }

--- a/ffi/athcon/bindings/rust/athcon-vm/Cargo.toml
+++ b/ffi/athcon/bindings/rust/athcon-vm/Cargo.toml
@@ -13,4 +13,4 @@ athena-interface = { path = "../../../../../interface" }
 athena-vm-sdk = { path = "../../../../../vm/sdk", default-features = false }
 
 [dev-dependencies]
-parity-scale-codec = "3.7.0"
+parity-scale-codec = "3.6.12"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 blake3 = "1.5.3"
 bytemuck = "1.20.0"
 hex = "0.4.3"
-parity-scale-codec = { version = "3.7.0", features = ["derive"] }
+parity-scale-codec = { version = "3.6.12", features = ["derive"] }
 serde = { version = "1.0.215", features = ["derive"] }
 tracing = "0.1.40"
 mockall = "0.13.1"

--- a/tests/entrypoint/Cargo.lock
+++ b/tests/entrypoint/Cargo.lock
@@ -264,16 +264,15 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
@@ -392,12 +391,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "serde"

--- a/tests/entrypoint/Cargo.lock
+++ b/tests/entrypoint/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-declare"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "athena-vm",

--- a/tests/panic/Cargo.lock
+++ b/tests/panic/Cargo.lock
@@ -241,16 +241,15 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be4817d39f3272f69c59fe05d0535ae6456c2dc2fa1ba02910296c7e0a5c590"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
@@ -369,12 +368,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "serde"

--- a/tests/panic/Cargo.lock
+++ b/tests/panic/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "athena-interface",
  "bincode",

--- a/vm/sdk/Cargo.toml
+++ b/vm/sdk/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 [dependencies]
 athena-vm = { path = "../entrypoint", optional = true }
 athena-interface = { path = "../../interface" }
-parity-scale-codec = { version = "3.7.0", features = ["derive"] }
+parity-scale-codec = { version = "3.6.12", features = ["derive"] }
 cfg-if = "1.0.0"
 serde = { version = "1.0", features = ["derive"] }
 


### PR DESCRIPTION
and prepare patch release v0.6.1.

I had to downgrade parity-scale-codec as version 3.7.0 was yanked.