### PR TITLE
the 'hint len' syscall returns 0 when no data

### DIFF
--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -77,6 +77,7 @@ impl SyscallCode {
   }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Outcome {
   Result(Option<u32>),
   Exit(u32),

--- a/vm/entrypoint/src/io.rs
+++ b/vm/entrypoint/src/io.rs
@@ -39,6 +39,9 @@ impl Write for SyscallWriter {
 pub fn read_vec() -> Vec<u8> {
   // Round up to the nearest multiple of 4 so that the memory allocated is in whole words
   let len = syscall_hint_len();
+  if len == 0 {
+    return vec![];
+  }
   let capacity = (len + 3) / 4 * 4;
 
   // Allocate a buffer of the required length that is 4 byte aligned


### PR DESCRIPTION
Previously, it failed with insufficient input error. The change lets the guest programs handle the situation when there is no more data.