### PR TITLE
allow template crates to have a lib target

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
   thread,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use cargo_metadata::camino::Utf8PathBuf;
 
 const BUILD_TARGET: &str = "riscv32em-athena-zkvm-elf";
@@ -200,26 +200,29 @@ fn copy_elf_to_output_dir(
   args: &BuildArgs,
   program_metadata: &cargo_metadata::Metadata,
 ) -> Result<Utf8PathBuf> {
-  let root_package = program_metadata.root_package();
-  let root_package_name = root_package.as_ref().map(|p| &p.name);
-  println!("Root package name: {:?}", root_package_name.unwrap());
+  let root_package = program_metadata
+    .root_package()
+    .ok_or(anyhow!("root package not found"))?;
+  println!("Root package name: {}", root_package.name);
 
   // Determine which target to use, and choose the artifact name based on the target type.
-  // For simplicity, we only consider the first target, and expect either bin or staticlib.
+  // For simplicity, we only consider the first bin or staticlib target.
   // Our target does not support dylib.
   // TODO: make this Mac and Windows-compatible.
-  let target = root_package.unwrap().targets.first().unwrap();
-  let artifact_name = if target.is_bin() {
-    root_package_name.unwrap()
-  } else if target.is_staticlib() {
-    &format!("lib{}.a", target.name)
-  } else {
-    panic!("Unsupported target kind");
-  };
-  println!(
-    "Target {:?} artifact path: {:?}",
-    target.name, artifact_name
-  );
+  let (target, artifact_name) = root_package
+    .targets
+    .iter()
+    .find_map(|t| {
+      if t.is_bin() {
+        Some((t, root_package.name.clone()))
+      } else if t.is_staticlib() {
+        Some((t, format!("lib{}.a", t.name)))
+      } else {
+        None
+      }
+    })
+    .ok_or(anyhow!("neither bin nor staticlib target found"))?;
+  println!("Target {} artifact path: {}", target.name, artifact_name);
 
   // The ELF is written to a target folder specified by the program's package.
   let original_elf_path = program_metadata
@@ -237,24 +240,20 @@ fn copy_elf_to_output_dir(
   } else if !args.binary.is_empty() {
     args.binary.clone()
   } else {
-    root_package_name.unwrap().to_string()
+    root_package.name.clone()
   };
 
   let elf_dir = root_package
-    .unwrap()
     .manifest_path
     .parent()
-    .unwrap()
+    .ok_or(anyhow!("couldn't find manifest path"))?
     .join(&args.output_directory);
   println!("Creating output dir {:?}", elf_dir);
   fs::create_dir_all(&elf_dir)?;
   let result_elf_path = elf_dir.join(elf_name);
 
   // Copy the ELF to the specified output directory.
-  println!(
-    "Copying original artifact {:?} to final path: {:?}",
-    original_elf_path, result_elf_path
-  );
+  println!("Copying original artifact {original_elf_path} to final path: {result_elf_path}");
   fs::copy(original_elf_path, &result_elf_path)?;
 
   Ok(result_elf_path)

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arrayref"
@@ -246,9 +246,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -1471,18 +1471,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/fibonacci/program/Cargo.lock
+++ b/examples/fibonacci/program/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"

--- a/examples/hello_world/program/Cargo.lock
+++ b/examples/hello_world/program/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"

--- a/examples/io/program/Cargo.lock
+++ b/examples/io/program/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"

--- a/examples/wallet/program/Cargo.lock
+++ b/examples/wallet/program/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"

--- a/tests/entrypoint/Cargo.lock
+++ b/tests/entrypoint/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"

--- a/tests/panic/Cargo.lock
+++ b/tests/panic/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"


### PR DESCRIPTION
Currently, the guest program crates, which are built with `cargo athena build` cannot have a `lib` target, or the building process panics. However, it is often useful to have a lib to be able to share common code with others (e.g. integration tests, publicly exporting contract types like its method arguments).

Additionally, replaced all unwraps in `copy_elf_to_output_dir` with returning an error.