### PR TITLE
integrate runtime hooks

### DIFF
--- a/core/src/runtime/hooks.rs
+++ b/core/src/runtime/hooks.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+
+use super::Runtime;
+
+#[mockall::automock]
+#[allow(clippy::needless_lifetimes)] // the lifetimes are needed by automock
+pub trait Hook {
+  fn execute<'r, 'h>(&self, env: HookEnv<'r, 'h>, data: &[u8]) -> anyhow::Result<Vec<u8>>;
+}
+
+/// A registry of hooks to call, indexed by the file descriptors through which they are accessed.
+#[derive(Default)]
+pub struct HookRegistry {
+  /// Table of registered hooks.
+  table: HashMap<u32, Box<dyn Hook>>,
+}
+
+impl HookRegistry {
+  /// Create a registry with the default hooks.
+  pub fn new() -> Self {
+    Default::default()
+  }
+
+  /// Register a hook under a given FD.
+  /// Will fail if a hook is already registered on a given FD
+  /// or a FD is <= 4.
+  pub fn register(&mut self, fd: u32, hook: Box<dyn Hook>) -> anyhow::Result<()> {
+    anyhow::ensure!(fd > 4, "FDs 0-4 are reserved for internal usage");
+    anyhow::ensure!(
+      !self.table.contains_key(&fd),
+      "there is already a hook for FD {fd} registered"
+    );
+    self.table.insert(fd, hook);
+    Ok(())
+  }
+
+  pub(crate) fn get(&self, fd: u32) -> Option<&dyn Hook> {
+    self.table.get(&fd).map(AsRef::as_ref)
+  }
+}
+
+/// Environment that a hook may read from.
+pub struct HookEnv<'r, 'h> {
+  pub runtime: &'r Runtime<'h>,
+}
+
+#[cfg(test)]
+pub mod tests {
+  use super::*;
+
+  #[test]
+  pub fn registry_new_is_empty() {
+    assert!(HookRegistry::new().table.is_empty());
+  }
+}

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod gdbstub;
+pub mod hooks;
 mod instruction;
 mod io;
 mod opcode;
@@ -8,6 +9,7 @@ mod state;
 mod syscall;
 mod utils;
 
+use anyhow::anyhow;
 use athena_interface::MethodSelector;
 pub use instruction::*;
 pub use opcode::*;
@@ -75,6 +77,8 @@ pub struct Runtime<'host> {
   pub max_syscall_cycles: u32,
 
   breakpoints: BTreeSet<u32>,
+
+  hook_registry: hooks::HookRegistry,
 }
 
 /// An record of a write to a memory address.
@@ -165,6 +169,7 @@ impl<'host> Runtime<'host> {
       syscall_map,
       max_syscall_cycles,
       breakpoints: BTreeSet::new(),
+      hook_registry: Default::default(),
     }
   }
 
@@ -813,6 +818,20 @@ impl<'host> Runtime<'host> {
   fn get_syscall(&mut self, code: SyscallCode) -> Option<&Arc<dyn Syscall>> {
     self.syscall_map.get(&code)
   }
+
+  /// Register a new hook.
+  /// Will fail if a hook is already registered on a given FD
+  /// or a FD is <= 4.
+  pub fn register_hook(&mut self, fd: u32, hook: Box<dyn hooks::Hook>) -> anyhow::Result<()> {
+    self.hook_registry.register(fd, hook)
+  }
+  pub(crate) fn execute_hook(&self, fd: u32, data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let hook = self
+      .hook_registry
+      .get(fd)
+      .ok_or_else(|| anyhow!("no hook registered for FD {fd}"))?;
+    hook.execute(hooks::HookEnv { runtime: self }, data)
+  }
 }
 
 #[cfg(test)]
@@ -828,7 +847,10 @@ pub mod tests {
     utils::{tests::TEST_PANIC_ELF, AthenaCoreOpts},
   };
 
-  use super::syscall::SyscallCode;
+  use super::{
+    hooks::{self, MockHook},
+    syscall::SyscallCode,
+  };
   use super::{Instruction, Opcode, Program, Runtime};
 
   pub fn simple_program() -> Program {
@@ -1738,6 +1760,53 @@ pub mod tests {
     // Assert SH cases
     assert_eq!(runtime.register(Register::X12), 0x12346525);
     assert_eq!(runtime.register(Register::X11), 0x65256525);
+  }
+
+  #[test]
+  fn registering_hook() {
+    let mut runtime = Runtime::new(
+      Program::new(vec![], 0, 0),
+      None,
+      AthenaCoreOpts::default(),
+      None,
+    );
+
+    // can't register on FD <= 4
+    for fd in 0..=4 {
+      runtime
+        .register_hook(fd, Box::new(hooks::MockHook::new()))
+        .unwrap_err();
+    }
+
+    // register on 5
+    runtime
+      .register_hook(5, Box::new(hooks::MockHook::new()))
+      .unwrap();
+
+    // can't register another hook on occupied FD
+    runtime
+      .register_hook(5, Box::new(hooks::MockHook::new()))
+      .unwrap_err();
+  }
+
+  #[test]
+  fn executing_hook() {
+    let mut runtime = Runtime::new(
+      Program::new(vec![], 0, 0),
+      None,
+      AthenaCoreOpts::default(),
+      None,
+    );
+
+    let mut hook = Box::new(MockHook::new());
+    hook.expect_execute().returning(|_, data| {
+      assert_eq!(&[1, 2, 3, 4], data);
+      Ok(vec![5, 6, 7])
+    });
+    runtime.register_hook(5, hook).unwrap();
+
+    let result = runtime.execute_hook(5, &[1, 2, 3, 4]).unwrap();
+    assert_eq!(vec![5, 6, 7], result);
   }
 }
 


### PR DESCRIPTION
Part of #60, integrating runtime hooks allowing guest programs to call custom registered code by writing on FD > 4.