### PR TITLE
limit the number of VM regs to 16 (RV32e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Athena
 
-Athena is a prototype deterministic smart contract engine that serves as the [Spacemesh network VM][2], and Athena is being designed and built by the  [Spacemesh][8] team. However, Athena is designed to be modular and largely protocol-agnostic so [it will run on other chains][9]. Contributions and integrations are welcome.
+Athena is a prototype deterministic smart contract engine that serves as the [Spacemesh network VM][2], and Athena is being designed and built by the [Spacemesh][8] team. However, Athena is designed to be modular and largely protocol-agnostic so [it will run on other chains][9]. Contributions and integrations are welcome.
 
-Athena includes a virtual machine (VM) based on the RISC-V ISA, including support for [RV32IM][10] and [RV32EM][1], an interpreter/compiler for running smart contract code, and related tooling. The VM is modular and features a mature FFI that can be integrated into any language that supports CFFI. For more information on the Athena project and its goals see [Introducing Athena][2] and the [Athena project updates][3].
+Athena includes a virtual machine (VM) based on the RISC-V ISA, including support for [RV32EM][1], an interpreter/compiler for running smart contract code, and related tooling. The VM features a C FFI that can be integrated into any language that supports interop with C. For more information on the Athena project and its goals see [Introducing Athena][2] and the [Athena project updates][3].
 
 ## Project Goals
 - **Developer Experience**: Provide a robust environment with extensive tooling support.

--- a/core/src/runtime/state.rs
+++ b/core/src/runtime/state.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 
 use nohash_hasher::BuildNoHashHasher;
 
+use super::Registers;
+
 /// Holds data describing the current state of a program's execution.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ExecutionState {
   /// The global clock keeps track of how many instrutions have been executed.
   pub global_clk: u64,
@@ -17,6 +19,8 @@ pub struct ExecutionState {
 
   /// The memory which instructions operate over.
   pub memory: HashMap<u32, u32, BuildNoHashHasher<u32>>,
+
+  pub(crate) regs: Registers,
 
   /// Uninitialized memory addresses that have a specific value they should be initialized with.
   /// SyscallHintRead uses this to write hint data into uninitialized memory.
@@ -42,6 +46,7 @@ impl ExecutionState {
       clk: 0,
       pc: pc_start,
       memory: HashMap::default(),
+      regs: Registers::new(super::Base::RV32E),
       uninitialized_memory: HashMap::default(),
       input_stream: Vec::new(),
       input_stream_ptr: 0,

--- a/core/src/runtime/utils.rs
+++ b/core/src/runtime/utils.rs
@@ -1,11 +1,6 @@
 use std::io::Write;
 
 use super::{Instruction, Runtime};
-use crate::runtime::Register;
-
-pub const fn align(addr: u32) -> u32 {
-  addr - addr % 4
-}
 
 impl Runtime<'_> {
   #[inline]
@@ -21,25 +16,7 @@ impl Runtime<'_> {
         clk = self.state.global_clk,
         pc = format_args!("0x{:x}", self.state.pc),
         instruction = ?instruction,
-        x0 = self.register(Register::X0),
-        x1 = self.register(Register::X1),
-        x2 = self.register(Register::X2),
-        x3 = self.register(Register::X3),
-        x4 = self.register(Register::X4),
-        x5 = self.register(Register::X5),
-        x6 = self.register(Register::X6),
-        x7 = self.register(Register::X7),
-        x8 = self.register(Register::X8),
-        x9 = self.register(Register::X9),
-        x10 = self.register(Register::X10),
-        x11 = self.register(Register::X11),
-        x12 = self.register(Register::X12),
-        x13 = self.register(Register::X13),
-        x14 = self.register(Register::X14),
-        x15 = self.register(Register::X15),
-        x16 = self.register(Register::X16),
-        x17 = self.register(Register::X17),
-        x18 = self.register(Register::X18),
+        registers = ?self.state.regs,
     );
 
     if !self.unconstrained && self.state.global_clk % 10_000_000 == 0 {

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -199,9 +199,7 @@ impl Syscall for SyscallHostSpawn {
     let host = ctx.rt.host.as_deref_mut().expect("Missing host interface");
     let address = host.spawn(blob);
 
-    let out_addr = ctx
-      .rt
-      .rr(Register::X12, crate::runtime::MemoryAccessPosition::A);
+    let out_addr = ctx.rt.rr(Register::X12);
 
     for (idx, c) in address.as_ref().chunks_exact(4).enumerate() {
       let v = u32::from_le_bytes(c.try_into().unwrap());
@@ -229,9 +227,7 @@ impl Syscall for SyscallHostDeploy {
     };
     tracing::debug!(%address, "deploy succeeded");
 
-    let out_addr = ctx
-      .rt
-      .rr(Register::X12, crate::runtime::MemoryAccessPosition::A);
+    let out_addr = ctx.rt.rr(Register::X12);
 
     for (idx, c) in address.as_ref().chunks_exact(4).enumerate() {
       let v = u32::from_le_bytes(c.try_into().unwrap());


### PR DESCRIPTION
Part of #18.

Removed registers X16+ from the VM and changed how they are represented in the VM from memory-mapped at "addresses" 0-15 to a separate structure that is also responsible for keeping invariants like the X0 always zero.

Note that, in many places in the VM, a raw `u32` taken from `Instruction` is converted to a `Register`, which may panic if the value is > 15. In the following PR, I will change disassembling logic to convert raw integers to `Register` enum variants at disassembly time to prevent panics at the guest program execution time.