### PR TITLE
simplistic token mint and wallet examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -392,6 +393,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "byteorder"

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -766,7 +766,10 @@ pub mod tests {
   use crate::{
     host::MockHostInterface, instruction::Instruction, runtime::ExecutionError, utils::with_max_gas,
   };
-  use athena_interface::{Address, AthenaContext, ExecutionResult, StatusCode, ADDRESS_LENGTH};
+  use athena_interface::{
+    Address, AthenaContext, CallerBuilder, ExecutionResult, StatusCode, ADDRESS_LENGTH,
+  };
+  use mockall::predicate::eq;
 
   use crate::{
     runtime::Register,
@@ -801,7 +804,8 @@ pub mod tests {
       Instruction::Add(Register::X15, Register::X14, Register::X13),
     ];
     let program = Program::new(instructions, 0, 0);
-    let ctx = AthenaContext::new(Address::default(), Address::default(), 0);
+    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let ctx = AthenaContext::new(Address::default(), caller, 0);
 
     // failure
     let mut runtime = Runtime::new(
@@ -914,7 +918,8 @@ pub mod tests {
       .expect_call()
       .once()
       .returning(|_| ExecutionResult::new(StatusCode::Success, 1000, None));
-    let ctx = AthenaContext::new(Address::default(), Address::default(), 0);
+    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let ctx = AthenaContext::new(Address::default(), caller, 0);
     let opts = AthenaCoreOpts::default().with_options(vec![with_max_gas(100000)]);
 
     let mut runtime = Runtime::new(program, Some(&mut host), opts, Some(ctx));
@@ -944,7 +949,9 @@ pub mod tests {
     ];
     let program = Program::new(instructions, 0, 0);
 
-    let ctx = AthenaContext::new(Address::default(), Address::default(), 0);
+    let callee = Address::from([0x77; 24]);
+    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let ctx = AthenaContext::new(callee, caller, 0);
     let opts = AthenaCoreOpts::default().with_options(vec![with_max_gas(100000)]);
     let mut host = MockHostInterface::new();
     host
@@ -978,11 +985,16 @@ pub mod tests {
       Instruction::Ecall,
     ];
     let program = Program::new(instructions, 0, 0);
+    let callee = Address([0x77; 24]);
+    let caller = CallerBuilder::new(Address([0x88; 24])).build();
 
-    let ctx = AthenaContext::new(Address::default(), Address::default(), 0);
+    let ctx = AthenaContext::new(callee, caller, 0);
     let opts = AthenaCoreOpts::default().with_options(vec![with_max_gas(100000)]);
     let mut host = MockHostInterface::new();
-    host.expect_get_balance().return_const(1111u64);
+    host
+      .expect_get_balance()
+      .with(eq(callee))
+      .return_const(1111u64);
 
     let mut runtime = Runtime::new(program, Some(&mut host), opts, Some(ctx));
     let gas_left = runtime.execute().expect("execution failed");

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -767,7 +767,7 @@ pub mod tests {
     host::MockHostInterface, instruction::Instruction, runtime::ExecutionError, utils::with_max_gas,
   };
   use athena_interface::{
-    Address, AthenaContext, CallerBuilder, ExecutionResult, StatusCode, ADDRESS_LENGTH,
+    Address, AthenaContext, Caller, ExecutionResult, StatusCode, ADDRESS_LENGTH,
   };
   use mockall::predicate::eq;
 
@@ -804,7 +804,10 @@ pub mod tests {
       Instruction::Add(Register::X15, Register::X14, Register::X13),
     ];
     let program = Program::new(instructions, 0, 0);
-    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let caller = Caller {
+      account: Address([0x88; 24]),
+      template: Address::default(),
+    };
     let ctx = AthenaContext::new(Address::default(), caller, 0);
 
     // failure
@@ -918,7 +921,10 @@ pub mod tests {
       .expect_call()
       .once()
       .returning(|_| ExecutionResult::new(StatusCode::Success, 1000, None));
-    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let caller = Caller {
+      account: Address([0x88; 24]),
+      template: Address::default(),
+    };
     let ctx = AthenaContext::new(Address::default(), caller, 0);
     let opts = AthenaCoreOpts::default().with_options(vec![with_max_gas(100000)]);
 
@@ -950,7 +956,10 @@ pub mod tests {
     let program = Program::new(instructions, 0, 0);
 
     let callee = Address::from([0x77; 24]);
-    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let caller = Caller {
+      account: Address([0x88; 24]),
+      template: Address::default(),
+    };
     let ctx = AthenaContext::new(callee, caller, 0);
     let opts = AthenaCoreOpts::default().with_options(vec![with_max_gas(100000)]);
     let mut host = MockHostInterface::new();
@@ -986,7 +995,10 @@ pub mod tests {
     ];
     let program = Program::new(instructions, 0, 0);
     let callee = Address([0x77; 24]);
-    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let caller = Caller {
+      account: Address([0x88; 24]),
+      template: Address::default(),
+    };
 
     let ctx = AthenaContext::new(callee, caller, 0);
     let opts = AthenaCoreOpts::default().with_options(vec![with_max_gas(100000)]);

--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -7,8 +7,9 @@ use strum_macros::EnumIter;
 use crate::runtime::{Register, Runtime};
 use crate::syscall::precompiles::ed25519::SyscallEd25519Verify;
 use crate::syscall::{
-  SyscallHalt, SyscallHintLen, SyscallHintRead, SyscallHostCall, SyscallHostDeploy,
-  SyscallHostGetBalance, SyscallHostRead, SyscallHostSpawn, SyscallHostWrite, SyscallWrite,
+  SyscallHalt, SyscallHintLen, SyscallHintRead, SyscallHostCall, SyscallHostContext,
+  SyscallHostDeploy, SyscallHostGetBalance, SyscallHostRead, SyscallHostSpawn, SyscallHostWrite,
+  SyscallWrite,
 };
 
 /// A system call is invoked by the the `ecall` instruction with a specific value in register t0.
@@ -37,6 +38,7 @@ pub enum SyscallCode {
   HOST_GETBALANCE = 0x00_00_00_A3,
   HOST_SPAWN = 0x00_00_00_A4,
   HOST_DEPLOY = 0x00_00_00_A5,
+  HOST_CONTEXT = 0x00_00_00_A6,
 
   /// Executes the `HINT_LEN` precompile.
   HINT_LEN = 0x00_00_00_F0,
@@ -58,6 +60,7 @@ impl SyscallCode {
       0x00_00_00_A3 => SyscallCode::HOST_GETBALANCE,
       0x00_00_00_A4 => SyscallCode::HOST_SPAWN,
       0x00_00_00_A5 => SyscallCode::HOST_DEPLOY,
+      0x00_00_00_A6 => SyscallCode::HOST_CONTEXT,
       0x00_00_00_F0 => SyscallCode::HINT_LEN,
       0x00_00_00_F1 => SyscallCode::HINT_READ,
       _ => panic!("invalid syscall number: {}", value),
@@ -205,6 +208,7 @@ pub fn default_syscall_map() -> HashMap<SyscallCode, Arc<dyn Syscall>> {
   syscall_map.insert(SyscallCode::HOST_DEPLOY, Arc::new(SyscallHostDeploy {}));
   syscall_map.insert(SyscallCode::HINT_LEN, Arc::new(SyscallHintLen {}));
   syscall_map.insert(SyscallCode::HINT_READ, Arc::new(SyscallHintRead {}));
+  syscall_map.insert(SyscallCode::HOST_CONTEXT, Arc::new(SyscallHostContext {}));
 
   syscall_map
 }
@@ -264,6 +268,7 @@ mod tests {
         SyscallCode::HINT_LEN => assert_eq!(code as u32, athena_vm::syscalls::HINT_LEN),
         SyscallCode::HINT_READ => assert_eq!(code as u32, athena_vm::syscalls::HINT_READ),
         SyscallCode::HOST_DEPLOY => assert_eq!(code as u32, athena_vm::syscalls::HOST_DEPLOY),
+        SyscallCode::HOST_CONTEXT => assert_eq!(code as u32, athena_vm::syscalls::HOST_CONTEXT),
       }
     }
   }

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -1,7 +1,34 @@
 use std::cmp::min;
 
 use crate::runtime::{Outcome, Register, Syscall, SyscallContext, SyscallResult};
-use athena_interface::{Address, AthenaMessage, MessageKind, StatusCode};
+use athena_interface::{Address, AthenaMessage, Context, MessageKind, StatusCode};
+
+pub(crate) struct SyscallHostContext;
+
+impl Syscall for SyscallHostContext {
+  fn execute(&self, ctx: &mut SyscallContext, address: u32, _: u32) -> SyscallResult {
+    let athena_ctx = ctx
+      .rt
+      .context
+      .as_ref()
+      .expect("Missing Athena runtime context");
+
+    let context = Context {
+      received: athena_ctx.received,
+      caller: athena_ctx.caller.account,
+      caller_template: athena_ctx.caller.template.unwrap_or_default(),
+    };
+
+    if (address % 4) != 0 {
+      return Err(StatusCode::InvalidMemoryAccess);
+    }
+
+    let context_bytes = bytemuck::bytes_of(&context);
+    ctx.mw_slice(address, bytemuck::cast_slice::<u8, u32>(context_bytes));
+
+    Ok(Outcome::Result(None))
+  }
+}
 
 pub(crate) struct SyscallHostRead;
 
@@ -17,7 +44,7 @@ impl Syscall for SyscallHostRead {
 
     // read value from host
     let host = ctx.rt.host.as_mut().expect("Missing host interface");
-    let value = host.get_storage(athena_ctx.address(), &key);
+    let value = host.get_storage(&athena_ctx.callee, &key);
 
     // set return value
     ctx.mw_slice(arg1, &bytemuck::cast::<_, [u32; 8]>(value));
@@ -41,7 +68,7 @@ impl Syscall for SyscallHostWrite {
 
     // write value to host
     let host = ctx.rt.host.as_deref_mut().expect("Missing host interface");
-    let status_code = host.set_storage(athena_ctx.address(), &key, &value);
+    let status_code = host.set_storage(&athena_ctx.callee, &key, &value);
 
     Ok(Outcome::Result(Some(status_code as u32)))
   }
@@ -92,10 +119,10 @@ impl Syscall for SyscallHostCall {
     // construct the outbound message
     let msg = AthenaMessage::new(
       MessageKind::Call,
-      athena_ctx.depth() + 1,
+      athena_ctx.depth + 1,
       gas_left,
       address,
-      *athena_ctx.address(),
+      athena_ctx.callee,
       input,
       amount,
     );
@@ -172,7 +199,7 @@ impl Syscall for SyscallHostGetBalance {
 
     // get value from host
     let host = ctx.rt.host.as_deref_mut().expect("Missing host interface");
-    let balance = host.get_balance(athena_ctx.address());
+    let balance = host.get_balance(&athena_ctx.callee);
     let balance_high = (balance >> 32) as u32;
     let balance_low = balance as u32;
     let balance_slice = [balance_low, balance_high];
@@ -235,7 +262,7 @@ impl Syscall for SyscallHostDeploy {
 
 #[cfg(test)]
 mod tests {
-  use athena_interface::{Address, AthenaContext, ExecutionResult};
+  use athena_interface::{Address, AthenaContext, CallerBuilder, ExecutionResult};
 
   use crate::{
     host::MockHostInterface,
@@ -253,7 +280,8 @@ mod tests {
       .withf(|m| m.depth == 1)
       .returning(|_| ExecutionResult::new(StatusCode::Success, 0, None));
 
-    let context = AthenaContext::new(Address::default(), Address::default(), 0);
+    let caller = CallerBuilder::new(Address::default()).build();
+    let context = AthenaContext::new(Address::default(), caller, 0);
     let mut runtime = runtime::Runtime::new(
       Program::new(vec![], 0, 0),
       Some(&mut host),

--- a/core/src/syscall/host.rs
+++ b/core/src/syscall/host.rs
@@ -15,8 +15,9 @@ impl Syscall for SyscallHostContext {
 
     let context = Context {
       received: athena_ctx.received,
+      callee: athena_ctx.callee,
       caller: athena_ctx.caller.account,
-      caller_template: athena_ctx.caller.template.unwrap_or_default(),
+      caller_template: athena_ctx.caller.template,
     };
 
     if (address % 4) != 0 {
@@ -262,7 +263,7 @@ impl Syscall for SyscallHostDeploy {
 
 #[cfg(test)]
 mod tests {
-  use athena_interface::{Address, AthenaContext, CallerBuilder, ExecutionResult};
+  use athena_interface::{Address, AthenaContext, Caller, ExecutionResult};
 
   use crate::{
     host::MockHostInterface,
@@ -280,7 +281,10 @@ mod tests {
       .withf(|m| m.depth == 1)
       .returning(|_| ExecutionResult::new(StatusCode::Success, 0, None));
 
-    let caller = CallerBuilder::new(Address::default()).build();
+    let caller = Caller {
+      account: Address::default(),
+      template: Address::default(),
+    };
     let context = AthenaContext::new(Address::default(), caller, 0);
     let mut runtime = runtime::Runtime::new(
       Program::new(vec![], 0, 0),

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -245,9 +245,24 @@ dependencies = [
 [[package]]
 name = "athena-vm-declare"
 version = "0.6.3"
+dependencies = [
+ "athena-vm-declare-macro 0.6.3",
+]
+
+[[package]]
+name = "athena-vm-declare"
+version = "0.6.3"
 source = "git+https://github.com/athenavm/athena?tag=v0.6.3#66ff76c86e08ec7c049122dac131421c507bf0c6"
 dependencies = [
- "athena-vm-declare-macro",
+ "athena-vm-declare-macro 0.6.3 (git+https://github.com/athenavm/athena?tag=v0.6.3)",
+]
+
+[[package]]
+name = "athena-vm-declare-macro"
+version = "0.6.3"
+dependencies = [
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -477,7 +492,7 @@ dependencies = [
  "athena-runner 0.6.3 (git+https://github.com/athenavm/athena?tag=v0.6.3)",
  "athena-sdk 0.6.3 (git+https://github.com/athenavm/athena?tag=v0.6.3)",
  "athena-vm 0.6.3 (git+https://github.com/athenavm/athena?tag=v0.6.3)",
- "athena-vm-declare",
+ "athena-vm-declare 0.6.3 (git+https://github.com/athenavm/athena?tag=v0.6.3)",
  "athena-vm-sdk 0.6.3 (git+https://github.com/athenavm/athena?tag=v0.6.3)",
  "contract_template",
  "ed25519-dalek",
@@ -1069,6 +1084,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mint"
+version = "0.1.0"
+dependencies = [
+ "athena-interface 0.6.3",
+ "athena-vm 0.6.3",
+ "athena-vm-declare 0.6.3",
+ "athena-vm-sdk 0.6.3",
+ "parity-scale-codec",
+ "wallet",
+]
 
 [[package]]
 name = "mockall"
@@ -1851,6 +1878,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wallet"
+version = "0.1.0"
+dependencies = [
+ "athena-interface 0.6.3",
+ "athena-vm 0.6.3",
+ "athena-vm-declare 0.6.3",
+ "athena-vm-sdk 0.6.3",
+ "parity-scale-codec",
+]
 
 [[package]]
 name = "wallet-script"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -149,6 +149,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -369,6 +370,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "byteorder"
@@ -1093,6 +1108,7 @@ dependencies = [
  "athena-vm 0.6.3",
  "athena-vm-declare 0.6.3",
  "athena-vm-sdk 0.6.3",
+ "bytemuck",
  "parity-scale-codec",
  "wallet",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@ members = [
   "contract_template",
   "fibonacci/script",
   "hello_world/script",
-  "io/script",
+  "io/script", "token/mint", "token/wallet",
   "wallet/script",
 ]
 resolver = "2"

--- a/examples/fibonacci/program/Cargo.lock
+++ b/examples/fibonacci/program/Cargo.lock
@@ -19,6 +19,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -82,6 +83,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
 
 [[package]]
 name = "byteorder"

--- a/examples/hello_world/program/Cargo.lock
+++ b/examples/hello_world/program/Cargo.lock
@@ -19,6 +19,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -82,6 +83,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
 
 [[package]]
 name = "byteorder"

--- a/examples/io/program/Cargo.lock
+++ b/examples/io/program/Cargo.lock
@@ -19,6 +19,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -82,6 +83,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
 
 [[package]]
 name = "byteorder"

--- a/examples/token/mint/Cargo.toml
+++ b/examples/token/mint/Cargo.toml
@@ -10,6 +10,7 @@ athena-vm = { path = "../../../vm/entrypoint" }
 athena-vm-declare = { path = "../../../vm/declare" }
 athena-vm-sdk = { path = "../../../vm/sdk" }
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
+bytemuck = { version = "1.21.0" }
 
 [profile.release]
 lto = true

--- a/examples/token/mint/Cargo.toml
+++ b/examples/token/mint/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mint"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wallet = { path = "../wallet" }
+athena-interface = { path = "../../../interface" }
+athena-vm = { path = "../../../vm/entrypoint" }
+athena-vm-declare = { path = "../../../vm/declare" }
+athena-vm-sdk = { path = "../../../vm/sdk" }
+parity-scale-codec = { version = "3.6.12", features = ["derive"] }
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/examples/token/mint/src/contract.rs
+++ b/examples/token/mint/src/contract.rs
@@ -1,0 +1,85 @@
+//! Token mint
+//!
+//! It allows exchanging SMH for the token,
+//! which is then transfered to the chosen
+//! wallet address.
+//!
+//! Every mint account instance represents a
+//! unique token.
+use athena_interface::Address;
+use athena_vm_declare::{callable, template};
+use athena_vm_sdk::{wallet::SpendArguments, Pubkey};
+use parity_scale_codec::{Decode, Encode};
+
+/// Storage for the number of already distributed tokens
+const SUPPLY_KEY: [u32; 8] = [0; 8];
+
+#[derive(Debug, Decode, Encode)]
+struct Mint {
+  owner: Pubkey,
+  max_supply: u64,
+  /// token/smidge ratio (how many smidges per token)
+  token_price: u64,
+}
+
+#[template]
+impl Mint {
+  #[callable]
+  fn spawn(mint: Mint) -> Address {
+    athena_vm_sdk::spawn(&mint.encode())
+  }
+
+  /// Buy exchanges SMH transfered along with the call into
+  /// TOKENS sent to the `recipient` address.
+  ///
+  /// The `recipient` must be address of a wallet.
+  #[callable]
+  fn buy(&self, recipient: Address) {
+    // 1. Check number of received coins
+    //    and convert to tokens
+    let ctx = athena_vm::syscalls::context::context();
+    let amount = ctx.received / self.token_price;
+    if amount == 0 {
+      return;
+    }
+
+    // 2. Check the remaining supply,
+    //    calculate how much is bought,
+    //    and update the remaining supply
+    let mut distributed_words = athena_vm::syscalls::read_storage(&SUPPLY_KEY);
+    let mut distributed = (distributed_words[0] as u64) + ((distributed_words[1] as u64) << 32);
+    let supply = self.max_supply.saturating_sub(distributed);
+    let bought = std::cmp::min(supply, amount);
+    distributed += bought;
+    distributed_words[0] = distributed as u32;
+    distributed_words[1] = (distributed >> 32) as u32;
+    athena_vm::syscalls::write_storage(&SUPPLY_KEY, &distributed_words);
+
+    // 3. Call receive() on the wallet.
+    // It will increase its balance
+    athena_vm_sdk::call(
+      recipient,
+      Some(
+        wallet::ReceiveArguments {
+          token_identifier: ctx.callee,
+          amount,
+        }
+        .encode(),
+      ),
+      Some(wallet::SELECTOR_RECEIVE),
+      0,
+    );
+
+    // 4. TODO: send back SMH that wasn't spent?
+  }
+
+  #[callable]
+  fn spend(&self, args: SpendArguments) {
+    athena_vm_sdk::call(args.recipient, None, None, args.amount);
+  }
+
+  #[callable]
+  fn verify(&self, tx: Vec<u8>, signature: [u8; 64]) -> bool {
+    athena_vm_sdk::precompiles::ed25519::verify(&tx, &self.owner.0, &signature)
+  }
+}

--- a/examples/token/mint/src/main.rs
+++ b/examples/token/mint/src/main.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+use athena_interface::{Address, Encode, MethodSelector};
+use athena_vm::entrypoint;
+use athena_vm_declare::{callable, template};
+use athena_vm_sdk::{wallet::SpendArguments, Pubkey};
+use parity_scale_codec::Decode;
+
+/// 1000 Smidge == 1 tokens
+const EXCHANGE_RATE: u64 = 1000;
+const SUPPLY_KEY: [u32; 8] = [0; 8];
+
+#[derive(Debug, Decode, Encode)]
+struct Mint {
+  owner: Pubkey,
+  max_supply: u64,
+}
+
+athena_vm::entrypoint!();
+
+#[template]
+impl Mint {
+  #[callable]
+  fn spawn(mint: Mint) -> Address {
+    let mut max_supply = [0u32; 8];
+    max_supply[0] = mint.max_supply as u32;
+    max_supply[1] = (mint.max_supply >> 32) as u32;
+    athena_vm::syscalls::write_storage(&SUPPLY_KEY, &max_supply);
+    athena_vm_sdk::spawn(mint.encode())
+  }
+
+  /// Buy exchanges SMH transfered along with the call into
+  /// TOKENS sent to the `recipient` address.
+  ///
+  /// The `recipient` must be address of a wallet.
+  #[callable]
+  fn buy(&self, recipient: Address) {
+    // 1. Check number of received coins
+    //    and convert to tokens
+    let ctx = athena_vm::syscalls::context::context();
+    let amount = ctx.received * EXCHANGE_RATE;
+    if amount == 0 {
+      return;
+    }
+
+    // 2. Check the remaining supply,
+    //    calculate how much is bought,
+    //    and update the remaining supply
+    let mut supply_words = athena_vm::syscalls::read_storage(&SUPPLY_KEY);
+    let mut supply = (supply_words[0] as u64) + ((supply_words[1] as u64) << 32);
+    let bought = std::cmp::min(supply, amount);
+    supply -= bought;
+    supply_words[0] = supply as u32;
+    supply_words[1] = (supply >> 32) as u32;
+    athena_vm::syscalls::write_storage(&SUPPLY_KEY, &supply_words);
+
+    // 3. Call receive() on the wallet.
+    // It will increase its balance
+    athena_vm_sdk::call(
+      recipient,
+      Some(wallet::ReceiveArguments { amount }.encode()),
+      Some(MethodSelector::from("athexp_receive")),
+      0,
+    );
+
+    // 4. TODO: send back SMH that wasn't spent?
+  }
+
+  #[callable]
+  fn spend(&self, args: SpendArguments) {
+    athena_vm_sdk::call(args.recipient, None, None, args.amount);
+  }
+
+  #[callable]
+  fn verify(&self, tx: Vec<u8>, signature: [u8; 64]) -> bool {
+    athena_vm_sdk::precompiles::ed25519::verify(&tx, &self.owner.0, &signature)
+  }
+}

--- a/examples/token/mint/src/main.rs
+++ b/examples/token/mint/src/main.rs
@@ -1,103 +1,12 @@
-//! Token mint
-//!
-//! It allows exchanging SMH for the token,
-//! which is then transfered to the chosen
-//! wallet address.
-//!
-//! Every mint account instance represents a
-//! unique token.
-#![no_main]
+#![cfg_attr(target_os = "zkvm", no_main)]
 
-use athena_interface::{Address, Encode, MethodSelector};
+#[cfg(target_os = "zkvm")]
+mod contract;
+
+#[cfg(target_os = "zkvm")]
 use athena_vm::entrypoint;
-use athena_vm_declare::{callable, template};
-use athena_vm_sdk::{wallet::SpendArguments, Pubkey};
-use parity_scale_codec::Decode;
-
-/// Storage for the number of already distributed tokens
-const SUPPLY_KEY: [u32; 8] = [0; 8];
-const TOKEN_IDENTIFIER_KEY: [u32; 8] = [1; 8];
-
-#[derive(Debug, Decode, Encode)]
-struct Mint {
-  owner: Pubkey,
-  max_supply: u64,
-  /// token/smidge ratio (how many smidges per token)
-  token_price: u64,
-}
-
+#[cfg(target_os = "zkvm")]
 athena_vm::entrypoint!();
 
-#[template]
-impl Mint {
-  #[callable]
-  fn spawn(mint: Mint) -> Address {
-    let address = athena_vm_sdk::spawn(&mint.encode());
-
-    let mut token_identifier_words = [0u32; 8];
-    for (i, c) in address.0.chunks_exact(4).enumerate() {
-      token_identifier_words[i] = u32::from_le_bytes(c.try_into().unwrap());
-    }
-    athena_vm::syscalls::write_storage(&TOKEN_IDENTIFIER_KEY, &token_identifier_words);
-    address
-  }
-
-  /// Buy exchanges SMH transfered along with the call into
-  /// TOKENS sent to the `recipient` address.
-  ///
-  /// The `recipient` must be address of a wallet.
-  #[callable]
-  fn buy(&self, recipient: Address) {
-    // 1. Check number of received coins
-    //    and convert to tokens
-    let ctx = athena_vm::syscalls::context::context();
-    let amount = ctx.received / self.token_price;
-    if amount == 0 {
-      return;
-    }
-
-    // 2. Check the remaining supply,
-    //    calculate how much is bought,
-    //    and update the remaining supply
-    let mut distributed_words = athena_vm::syscalls::read_storage(&SUPPLY_KEY);
-    let mut distributed = (distributed_words[0] as u64) + ((distributed_words[1] as u64) << 32);
-    let supply = self.max_supply.saturating_sub(distributed);
-    let bought = std::cmp::min(supply, amount);
-    distributed += bought;
-    distributed_words[0] = distributed as u32;
-    distributed_words[1] = (distributed >> 32) as u32;
-    athena_vm::syscalls::write_storage(&SUPPLY_KEY, &distributed_words);
-
-    let token_identifier_words = athena_vm::syscalls::read_storage(&TOKEN_IDENTIFIER_KEY);
-    let token_identifier: [u8; 24] = bytemuck::cast_slice::<u32, u8>(&token_identifier_words)[..24]
-      .try_into()
-      .unwrap();
-
-    // 3. Call receive() on the wallet.
-    // It will increase its balance
-    athena_vm_sdk::call(
-      recipient,
-      Some(
-        wallet::ReceiveArguments {
-          token_identifier: Address(token_identifier),
-          amount,
-        }
-        .encode(),
-      ),
-      Some(MethodSelector::from("athexp_receive")),
-      0,
-    );
-
-    // 4. TODO: send back SMH that wasn't spent?
-  }
-
-  #[callable]
-  fn spend(&self, args: SpendArguments) {
-    athena_vm_sdk::call(args.recipient, None, None, args.amount);
-  }
-
-  #[callable]
-  fn verify(&self, tx: Vec<u8>, signature: [u8; 64]) -> bool {
-    athena_vm_sdk::precompiles::ed25519::verify(&tx, &self.owner.0, &signature)
-  }
-}
+#[cfg(not(target_os = "zkvm"))]
+pub fn main() {}

--- a/examples/token/wallet/Cargo.toml
+++ b/examples/token/wallet/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "wallet"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+athena-interface = { path = "../../../interface" }
+athena-vm = { path = "../../../vm/entrypoint" }
+athena-vm-declare = { path = "../../../vm/declare" }
+athena-vm-sdk = { path = "../../../vm/sdk" }
+parity-scale-codec = { version = "3.6.12", features = ["derive"] }
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/examples/token/wallet/src/contract.rs
+++ b/examples/token/wallet/src/contract.rs
@@ -1,0 +1,99 @@
+//! Multi-token wallet
+//!
+//! It keeps and allows spending various tokens
+//! created by different mints. Every mint
+//! instance creates a unique token, which
+//! is identified by the address of the mint.
+
+use athena_interface::Address;
+use athena_vm_declare::{callable, template};
+use athena_vm_sdk::Pubkey;
+use parity_scale_codec::{Decode, Encode};
+use wallet::{ReceiveArguments, SpendArguments};
+
+#[derive(Debug, Decode, Encode)]
+struct Wallet {
+  owner: Pubkey,
+  mint_template: Address,
+  wallet_template: Address,
+}
+
+#[template]
+impl Wallet {
+  #[callable]
+  fn spawn(state: Wallet) -> Address {
+    athena_vm_sdk::spawn(&state.encode())
+  }
+
+  #[callable]
+  fn receive(&self, args: ReceiveArguments) {
+    // 1. Only accept calls from the following templates:
+    // - the mint (exchange)
+    // - another wallet (transfer)
+    let ctx = athena_vm::syscalls::context::context();
+    assert!(
+      ctx.caller_template == self.mint_template || ctx.caller_template == self.wallet_template
+    );
+
+    // 2. increase the balance
+    let balance_key = self.balance_key(&args.token_identifier);
+    let mut balance_words = athena_vm::syscalls::read_storage(&balance_key);
+    let mut balance = (balance_words[0] as u64) + ((balance_words[1] as u64) << 32);
+    balance = balance.saturating_add(args.amount);
+    balance_words[0] = balance as u32;
+    balance_words[1] = (balance >> 32) as u32;
+    athena_vm::syscalls::write_storage(&balance_key, &balance_words);
+  }
+
+  fn balance_key(&self, token_id: &Address) -> [u32; 8] {
+    let mut balance_key = [0; 8];
+    for (i, chunk) in token_id.0.chunks_exact(4).enumerate() {
+      balance_key[i] = u32::from_le_bytes(chunk.try_into().unwrap())
+    }
+    balance_key
+  }
+
+  #[callable]
+  fn send_token(&self, args: SpendArguments) {
+    // 1. Decrease the balance
+    let balance_key = self.balance_key(&args.token_identifier);
+    let mut balance_words = athena_vm::syscalls::read_storage(&balance_key);
+    let mut balance = (balance_words[0] as u64) + ((balance_words[1] as u64) << 32);
+    assert!(args.amount <= balance);
+
+    balance -= args.amount;
+    balance_words[0] = balance as u32;
+    balance_words[1] = (balance >> 32) as u32;
+    athena_vm::syscalls::write_storage(&balance_key, &balance_words);
+
+    // 2. Call receive() on the other wallet
+    // It will increase its balance.
+    athena_vm_sdk::call(
+      args.recipient,
+      Some(
+        wallet::ReceiveArguments {
+          token_identifier: args.token_identifier,
+          amount: args.amount,
+        }
+        .encode(),
+      ),
+      Some(wallet::SELECTOR_RECEIVE),
+      0,
+    );
+  }
+
+  #[callable]
+  fn spend(&self, args: athena_vm_sdk::wallet::SpendArguments) {
+    athena_vm_sdk::call(args.recipient, None, None, args.amount);
+  }
+
+  #[callable]
+  fn max_spend(&self, args: athena_vm_sdk::wallet::SpendArguments) -> u64 {
+    args.amount
+  }
+
+  #[callable]
+  fn verify(&self, tx: Vec<u8>, signature: [u8; 64]) -> bool {
+    athena_vm_sdk::precompiles::ed25519::verify(&tx, &self.owner.0, &signature)
+  }
+}

--- a/examples/token/wallet/src/lib.rs
+++ b/examples/token/wallet/src/lib.rs
@@ -1,4 +1,4 @@
-use athena_interface::Address;
+use athena_interface::{Address, MethodSelector};
 use parity_scale_codec::{Decode, Encode};
 
 #[derive(Decode, Encode)]
@@ -16,4 +16,18 @@ pub struct SpendArguments {
   pub token_identifier: Address,
   pub recipient: Address,
   pub amount: u64,
+}
+
+pub const SELECTOR_RECEIVE: MethodSelector = MethodSelector([208, 20, 84, 100]);
+
+#[cfg(test)]
+mod tests {
+  use athena_interface::MethodSelector;
+
+  use crate::SELECTOR_RECEIVE;
+
+  #[test]
+  fn receive_method_selector() {
+    assert_eq!(SELECTOR_RECEIVE, MethodSelector::from("athexp_receive"));
+  }
 }

--- a/examples/token/wallet/src/lib.rs
+++ b/examples/token/wallet/src/lib.rs
@@ -1,0 +1,6 @@
+use parity_scale_codec::{Decode, Encode};
+
+#[derive(Decode, Encode)]
+pub struct ReceiveArguments {
+  pub amount: u64,
+}

--- a/examples/token/wallet/src/lib.rs
+++ b/examples/token/wallet/src/lib.rs
@@ -1,6 +1,19 @@
+use athena_interface::Address;
 use parity_scale_codec::{Decode, Encode};
 
 #[derive(Decode, Encode)]
 pub struct ReceiveArguments {
+  /// Token identifier allows identifing a token.
+  /// It is the address of the mint that produced this token.
+  pub token_identifier: Address,
+  pub amount: u64,
+}
+
+#[derive(Decode, Encode)]
+pub struct SpendArguments {
+  /// Token identifier allows identifing a token.
+  /// It is the address of the mint that produced this token.
+  pub token_identifier: Address,
+  pub recipient: Address,
   pub amount: u64,
 }

--- a/examples/token/wallet/src/main.rs
+++ b/examples/token/wallet/src/main.rs
@@ -1,0 +1,70 @@
+#![no_main]
+
+use athena_interface::{Address, MethodSelector};
+use athena_vm::entrypoint;
+use athena_vm_declare::{callable, template};
+use athena_vm_sdk::Pubkey;
+use parity_scale_codec::{Decode, Encode};
+use wallet::ReceiveArguments;
+
+const BALANCE_KEY: [u32; 8] = [0u32; 8];
+
+#[derive(Debug, Decode, Encode)]
+struct Wallet {
+  owner: Pubkey,
+  mint: Address,
+  template: Address,
+}
+
+athena_vm::entrypoint!();
+
+#[template]
+impl Wallet {
+  #[callable]
+  fn spawn(state: Wallet) -> Address {
+    athena_vm_sdk::spawn(&state.encode())
+  }
+
+  #[callable]
+  fn receive(&self, args: ReceiveArguments) {
+    // 1. Only accept calls from:
+    // - the mint (exchange)
+    // - another wallet
+    let ctx = athena_vm::syscalls::context::context();
+    // FIXME: This breaks if the mint isn't a singleton...
+    assert!(ctx.caller == self.mint || ctx.caller_template == self.template);
+
+    // 2. increase the balance
+    let mut balance_words = athena_vm::syscalls::read_storage(&[0u32; 8]);
+    let mut balance = (balance_words[0] as u64) + ((balance_words[1] as u64) << 32);
+    balance = balance.saturating_add(args.amount);
+    balance_words[0] = balance as u32;
+    balance_words[1] = (balance >> 32) as u32;
+    athena_vm::syscalls::write_storage(&BALANCE_KEY, &balance_words);
+  }
+
+  #[callable]
+  fn spend(&self, recipient: Address, amount: u64) {
+    // 1. Decrease the balance
+    let mut balance_words = athena_vm::syscalls::read_storage(&[0u32; 8]);
+    let mut balance = (balance_words[0] as u64) + ((balance_words[1] as u64) << 32);
+    balance = balance.saturating_sub(amount);
+    balance_words[0] = balance as u32;
+    balance_words[1] = (balance >> 32) as u32;
+    athena_vm::syscalls::write_storage(&BALANCE_KEY, &balance_words);
+
+    // 2. Call receive() on the other wallet
+    // It will increase its balance.
+    athena_vm_sdk::call(
+      recipient,
+      Some(wallet::ReceiveArguments { amount }.encode()),
+      Some(MethodSelector::from("athexp_receive")),
+      0,
+    );
+  }
+
+  #[callable]
+  fn verify(&self, tx: Vec<u8>, signature: [u8; 64]) -> bool {
+    athena_vm_sdk::precompiles::ed25519::verify(&tx, &self.owner.0, &signature)
+  }
+}

--- a/examples/token/wallet/src/main.rs
+++ b/examples/token/wallet/src/main.rs
@@ -1,99 +1,12 @@
-//! Multi-token wallet
-//!
-//! It keeps and allows spending various tokens
-//! created by different mints. Every mint
-//! instance creates a unique token, which
-//! is identified by the address of the mint.
-#![no_main]
+#![cfg_attr(target_os = "zkvm", no_main)]
 
-use athena_interface::{Address, MethodSelector};
+#[cfg(target_os = "zkvm")]
+mod contract;
+
+#[cfg(target_os = "zkvm")]
 use athena_vm::entrypoint;
-use athena_vm_declare::{callable, template};
-use athena_vm_sdk::Pubkey;
-use parity_scale_codec::{Decode, Encode};
-use wallet::{ReceiveArguments, SpendArguments};
-
-#[derive(Debug, Decode, Encode)]
-struct Wallet {
-  owner: Pubkey,
-  mint_template: Address,
-  wallet_template: Address,
-}
-
+#[cfg(target_os = "zkvm")]
 athena_vm::entrypoint!();
 
-#[template]
-impl Wallet {
-  #[callable]
-  fn spawn(state: Wallet) -> Address {
-    athena_vm_sdk::spawn(&state.encode())
-  }
-
-  #[callable]
-  fn receive(&self, args: ReceiveArguments) {
-    // 1. Only accept calls from the following templates:
-    // - the mint (exchange)
-    // - another wallet (transfer)
-    let ctx = athena_vm::syscalls::context::context();
-    assert!(
-      ctx.caller_template == self.mint_template || ctx.caller_template == self.wallet_template
-    );
-
-    // 2. increase the balance
-    let balance_key = self.balance_key(&args.token_identifier);
-    let mut balance_words = athena_vm::syscalls::read_storage(&balance_key);
-    let mut balance = (balance_words[0] as u64) + ((balance_words[1] as u64) << 32);
-    balance = balance.saturating_add(args.amount);
-    balance_words[0] = balance as u32;
-    balance_words[1] = (balance >> 32) as u32;
-    athena_vm::syscalls::write_storage(&balance_key, &balance_words);
-  }
-
-  fn balance_key(&self, token_id: &Address) -> [u32; 8] {
-    let mut balance_key = [0; 8];
-    for (i, chunk) in token_id.0.chunks_exact(4).enumerate() {
-      balance_key[i] = u32::from_le_bytes(chunk.try_into().unwrap())
-    }
-    balance_key
-  }
-
-  #[callable]
-  fn spend(&self, args: SpendArguments) {
-    // 1. Decrease the balance
-    let balance_key = self.balance_key(&args.token_identifier);
-    let mut balance_words = athena_vm::syscalls::read_storage(&balance_key);
-    let mut balance = (balance_words[0] as u64) + ((balance_words[1] as u64) << 32);
-    assert!(args.amount <= balance);
-
-    balance -= args.amount;
-    balance_words[0] = balance as u32;
-    balance_words[1] = (balance >> 32) as u32;
-    athena_vm::syscalls::write_storage(&balance_key, &balance_words);
-
-    // 2. Call receive() on the other wallet
-    // It will increase its balance.
-    athena_vm_sdk::call(
-      args.recipient,
-      Some(
-        wallet::ReceiveArguments {
-          token_identifier: args.token_identifier,
-          amount: args.amount,
-        }
-        .encode(),
-      ),
-      Some(MethodSelector::from("athexp_receive")),
-      0,
-    );
-  }
-
-  #[callable]
-  fn max_spend(&self) -> u64 {
-    // This wallet doesn't manage SMH and it cannot spend it.
-    0
-  }
-
-  #[callable]
-  fn verify(&self, tx: Vec<u8>, signature: [u8; 64]) -> bool {
-    athena_vm_sdk::precompiles::ed25519::verify(&tx, &self.owner.0, &signature)
-  }
-}
+#[cfg(not(target_os = "zkvm"))]
+pub fn main() {}

--- a/examples/wallet/program/Cargo.lock
+++ b/examples/wallet/program/Cargo.lock
@@ -16,16 +16,17 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "athena-interface"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "athena-vm"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "athena-interface",
  "bincode",
@@ -39,14 +40,14 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-declare"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "athena-vm-declare-macro",
 ]
 
 [[package]]
 name = "athena-vm-declare-macro"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "quote",
  "syn 2.0.82",
@@ -54,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "athena-vm-sdk"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "athena-interface",
  "athena-vm",
@@ -108,6 +109,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
 
 [[package]]
 name = "byteorder"

--- a/examples/wallet/script/src/host.rs
+++ b/examples/wallet/script/src/host.rs
@@ -201,7 +201,13 @@ impl HostInterface for MockHost {
         None => msg,
       };
 
-      AthenaVm::new().execute(self, AthenaRevision::AthenaFrontier, msg, &code)
+      AthenaVm::new().execute(
+        self,
+        AthenaRevision::AthenaFrontier,
+        msg,
+        &code,
+        Address::default(),
+      )
     } else {
       let gas_left = msg.gas.checked_sub(1).expect("gas underflow");
       ExecutionResult::new(StatusCode::Success, gas_left, None)

--- a/examples/wallet/script/src/main.rs
+++ b/examples/wallet/script/src/main.rs
@@ -9,7 +9,7 @@ use host::*;
 
 use std::error::Error;
 
-use athena_interface::{Address, AthenaContext, Encode, MethodSelector};
+use athena_interface::{Address, AthenaContext, CallerBuilder, Encode, MethodSelector};
 use athena_sdk::{host::HostInterface, AthenaStdin, ExecutionClient};
 use athena_vm_sdk::{wallet::SpendArguments, Pubkey};
 
@@ -50,8 +50,8 @@ fn main() {
   );
 
   // send some coins
-  let address_bob = Address::from([0xBB; 24]);
-  let context = AthenaContext::new(ADDRESS_ALICE, address_bob, 0);
+  let caller = CallerBuilder::new(Address::from([0xBB; 24])).build();
+  let context = AthenaContext::new(ADDRESS_ALICE, caller, 0);
 
   let mut stdin = AthenaStdin::new();
   let wallet = host
@@ -70,9 +70,7 @@ fn main() {
   assert!(alice_balance >= 120);
   println!(
     "sending {} coins {} -> {}",
-    args.amount,
-    context.address(),
-    args.recipient,
+    args.amount, context.caller.account, args.recipient,
   );
   // calculate method selector
   let method_selector = MethodSelector::from("athexp_spend");
@@ -107,7 +105,7 @@ mod tests {
     payload::ExecutionPayloadBuilder, payload::Payload, Address, AthenaMessage, Balance, Encode,
     MessageKind, MethodSelector, StatusCode,
   };
-  use athena_interface::{AthenaContext, Decode, ExecutionResult};
+  use athena_interface::{AthenaContext, CallerBuilder, Decode, ExecutionResult};
   use athena_runner::vm::AthenaRevision;
   use athena_runner::AthenaVm;
   use athena_sdk::host::MockHostInterface;
@@ -241,6 +239,7 @@ mod tests {
           Balance::default(),
         ),
         super::ELF,
+        Address::default(),
       );
 
       // the call should succeed, and it should return false
@@ -274,6 +273,7 @@ mod tests {
         Balance::default(),
       ),
       super::ELF,
+      Address::default(),
     );
 
     // the call should succeed, and it should return true
@@ -327,9 +327,10 @@ mod tests {
     stdin.write_vec(args.encode());
 
     let sender = ADDRESS_ALICE;
-    let context = AthenaContext::new(sender, Address::default(), 0);
+    let context = AthenaContext::new(sender, CallerBuilder::new(Address::default()).build(), 0);
     let mut host = MockHostInterface::new();
     host.expect_call().returning(move |msg| {
+      // the callee becomes the sender in the proxied call
       assert_eq!(sender, msg.sender);
       assert_eq!(args.destination, msg.recipient);
       assert_eq!(args.amount, msg.value);

--- a/ffi/athcon/bindings/go/athcon.go
+++ b/ffi/athcon/bindings/go/athcon.go
@@ -196,7 +196,7 @@ func (vm *VM) Execute(
 	kind CallKind,
 	depth int,
 	gas int64,
-	recipient, sender Address,
+	recipient, sender, sender_template Address,
 	input []byte,
 	value uint64,
 	code []byte,
@@ -208,12 +208,13 @@ func (vm *VM) Execute(
 		}
 	}
 	msg := C.struct_athcon_message{
-		kind:      C.enum_athcon_call_kind(kind),
-		depth:     C.int32_t(depth),
-		gas:       C.int64_t(gas),
-		recipient: *athconAddress(recipient),
-		sender:    *athconAddress(sender),
-		value:     C.uint64_t(value),
+		kind:            C.enum_athcon_call_kind(kind),
+		depth:           C.int32_t(depth),
+		gas:             C.int64_t(gas),
+		recipient:       *athconAddress(recipient),
+		sender:          *athconAddress(sender),
+		sender_template: *athconAddress(sender_template),
+		value:           C.uint64_t(value),
 	}
 	if len(input) > 0 {
 		// Allocate memory for input data in C.

--- a/ffi/athcon/bindings/go/athcon_test.go
+++ b/ffi/athcon/bindings/go/athcon_test.go
@@ -67,7 +67,7 @@ func TestExecuteEmptyCode(t *testing.T) {
 	defer vm.Destroy()
 
 	addr := Address{}
-	result, err := vm.Execute(nil, Frontier, Call, 1, 999, addr, addr, nil, 0, nil)
+	result, err := vm.Execute(nil, Frontier, Call, 1, 999, addr, addr, Address{}, nil, 0, nil)
 
 	require.Error(t, err)
 	require.Empty(t, result.Output)

--- a/ffi/athcon/bindings/go/host_test.go
+++ b/ffi/athcon/bindings/go/host_test.go
@@ -89,7 +89,7 @@ func (host *testHostContext) Call(
 	}
 
 	encoded := EncodedExecutionPayload(nil, input)
-	result, err := host.vm.Execute(host, Frontier, Call, depth+1, gas, recipient, sender, encoded, 0, p)
+	result, err := host.vm.Execute(host, Frontier, Call, depth+1, gas, recipient, sender, Address{}, encoded, 0, p)
 	if err != nil {
 		return nil, gas, fmt.Errorf("executing call: %w", err)
 	}
@@ -125,7 +125,7 @@ func TestGetBalance(t *testing.T) {
 	host := newHost(vm)
 	addr := randomAddress()
 	host.balances[addr] = 1000
-	result, err := vm.Execute(host, Frontier, Call, 1, 100, addr, addr, nil, 0, MINIMAL_TEST_CODE)
+	result, err := vm.Execute(host, Frontier, Call, 1, 100, addr, addr, Address{}, nil, 0, MINIMAL_TEST_CODE)
 	require.NoError(t, err)
 	require.EqualValues(t, result.GasLeft, 68)
 	require.Len(t, result.Output, 32)
@@ -152,7 +152,7 @@ func TestCall(t *testing.T) {
 
 	encoded, err := scale.Marshal(executionPayload)
 	require.NoError(t, err)
-	result, err := vm.Execute(host, Frontier, Call, 0, 100000, addr, addr, encoded, 0, RECURSIVE_CALL_TEST)
+	result, err := vm.Execute(host, Frontier, Call, 0, 100000, addr, addr, Address{}, encoded, 0, RECURSIVE_CALL_TEST)
 	require.NoError(t, err)
 	require.Len(t, result.Output, 4)
 	value := binary.LittleEndian.Uint32(result.Output)
@@ -170,7 +170,7 @@ func TestSpawn(t *testing.T) {
 	payload := vm.Lib.EncodeTxSpawn(pubkey)
 	executionPayload := EncodedExecutionPayload(nil, payload)
 
-	result, err := vm.Execute(host, Frontier, Call, 1, 1000000, principal, principal, executionPayload, 0, WALLET_TEST)
+	result, err := vm.Execute(host, Frontier, Call, 1, 1000000, principal, principal, Address{}, executionPayload, 0, WALLET_TEST)
 	require.NoError(t, err)
 	require.Len(t, result.Output, 24)
 
@@ -189,7 +189,7 @@ func TestSpend(t *testing.T) {
 		pubkey := Bytes32([32]byte{1, 1, 2, 2, 3, 3, 4, 4})
 		executionPayload := EncodedExecutionPayload(nil, vm.Lib.EncodeTxSpawn(pubkey))
 
-		result, err := vm.Execute(host, Frontier, Call, 1, 10000, principal, principal, executionPayload, 0, WALLET_TEST)
+		result, err := vm.Execute(host, Frontier, Call, 1, 10000, principal, principal, Address{}, executionPayload, 0, WALLET_TEST)
 		require.NoError(t, err)
 		require.Len(t, result.Output, 24)
 
@@ -204,7 +204,7 @@ func TestSpend(t *testing.T) {
 		host.programs[walletAddress],
 		vm.Lib.EncodeTxSpend(recipient, 100),
 	)
-	_, err := vm.Execute(host, Frontier, Call, 1, 10000, principal, principal, executionPayload, 0, WALLET_TEST)
+	_, err := vm.Execute(host, Frontier, Call, 1, 10000, principal, principal, Address{}, executionPayload, 0, WALLET_TEST)
 	require.NoError(t, err)
 
 	// Step 3: Check balance
@@ -225,7 +225,7 @@ func TestVerify(t *testing.T) {
 		pubkey := Bytes32(pubkey)
 		executionPayload := EncodedExecutionPayload(nil, vm.Lib.EncodeTxSpawn(pubkey))
 
-		result, err := vm.Execute(host, Frontier, Call, 1, 10000000, principal, principal, executionPayload, 0, WALLET_TEST)
+		result, err := vm.Execute(host, Frontier, Call, 1, 10000000, principal, principal, Address{}, executionPayload, 0, WALLET_TEST)
 		require.NoError(t, err)
 		require.Len(t, result.Output, 24)
 
@@ -253,7 +253,7 @@ func TestVerify(t *testing.T) {
 
 	executionPayload := EncodedExecutionPayload(host.programs[walletAddress], payloadEncoded)
 
-	result, err := vm.Execute(host, Frontier, Call, 1, 100000, principal, principal, executionPayload, 0, WALLET_TEST)
+	result, err := vm.Execute(host, Frontier, Call, 1, 100000, principal, principal, Address{}, executionPayload, 0, WALLET_TEST)
 	require.NoError(t, err)
 	require.Zero(t, result.Output[0])
 
@@ -271,7 +271,7 @@ func TestVerify(t *testing.T) {
 
 	executionPayload = EncodedExecutionPayload(host.programs[walletAddress], payloadEncoded)
 
-	result, err = vm.Execute(host, Frontier, Call, 1, 100000, principal, principal, executionPayload, 0, WALLET_TEST)
+	result, err = vm.Execute(host, Frontier, Call, 1, 100000, principal, principal, Address{}, executionPayload, 0, WALLET_TEST)
 	require.NoError(t, err)
 	require.Equal(t, uint8(1), result.Output[0])
 }

--- a/ffi/athcon/bindings/rust/athcon-vm/src/container.rs
+++ b/ffi/athcon/bindings/rust/athcon-vm/src/container.rs
@@ -117,6 +117,7 @@ mod tests {
       gas: 0,
       recipient: ::athcon_sys::athcon_address::default(),
       sender: ::athcon_sys::athcon_address::default(),
+      sender_template: ::athcon_sys::athcon_address::default(),
       input_data: std::ptr::null(),
       input_size: 0,
       value: 0,

--- a/ffi/athcon/include/athcon/athcon.h
+++ b/ffi/athcon/include/athcon/athcon.h
@@ -97,6 +97,8 @@ extern "C"
      */
     athcon_address sender;
 
+    athcon_address sender_template;
+
     /**
      * The message input data.
      *

--- a/ffi/vmlib/src/lib.rs
+++ b/ffi/vmlib/src/lib.rs
@@ -60,10 +60,13 @@ impl AthconVm for AthenaVMWrapper {
     let mut host = WrappedHostInterface::new(execution_context);
 
     // Execute the code and proxy the result back to the caller
-    let execution_result =
-      self
-        .athena_vm
-        .execute(&mut host, RevisionWrapper::from(rev).0, athena_msg.0, code);
+    let execution_result = self.athena_vm.execute(
+      &mut host,
+      RevisionWrapper::from(rev).0,
+      athena_msg.0,
+      code,
+      Address(message.sender_template.bytes),
+    );
     ExecutionResultWrapper(execution_result).into()
   }
 }

--- a/ffi/vmlib/tests/integration_tests.rs
+++ b/ffi/vmlib/tests/integration_tests.rs
@@ -72,6 +72,7 @@ fn test_athcon_create() {
       gas: 10000,
       recipient: ::athcon_sys::athcon_address::default(),
       sender: ::athcon_sys::athcon_address::default(),
+      sender_template: ::athcon_sys::athcon_address::default(),
       input_data: std::ptr::null(),
       input_size: 0,
       value: 0,

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -11,3 +11,4 @@ edition.workspace = true
 blake3 = "1.5.5"
 hex = "0.4.3"
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
+bytemuck = { version = "1.21.0", features = ["derive"] }

--- a/interface/src/context.rs
+++ b/interface/src/context.rs
@@ -16,32 +16,7 @@ pub struct AthenaContext {
 #[derive(Debug, Clone)]
 pub struct Caller {
   pub account: Address,
-  pub template: Option<Address>,
-}
-
-#[derive(Debug)]
-pub struct CallerBuilder {
-  caller: Caller,
-}
-
-impl CallerBuilder {
-  pub fn new(address: Address) -> CallerBuilder {
-    Self {
-      caller: Caller {
-        account: address,
-        template: None,
-      },
-    }
-  }
-
-  pub fn build(self) -> Caller {
-    self.caller
-  }
-
-  pub fn template(mut self, template: Address) -> Self {
-    self.caller.template = Some(template);
-    self
-  }
+  pub template: Address,
 }
 
 impl AthenaContext {
@@ -61,4 +36,5 @@ pub struct Context {
   pub received: u64,
   pub caller: Address,
   pub caller_template: Address,
+  pub callee: Address,
 }

--- a/interface/src/context.rs
+++ b/interface/src/context.rs
@@ -1,33 +1,64 @@
+use bytemuck::NoUninit;
+
+use crate::Address;
+
 /// The runtime context struct stores information received as part of the inbound
 /// execution message that's guaranteed not to change during the context of the
 /// program execution.
-use crate::Address;
-
 #[derive(Debug, Clone)]
 pub struct AthenaContext {
-  address: Address,
-  caller: Address,
-  depth: u32,
+  pub callee: Address,
+  pub caller: Caller,
+  pub depth: u32,
+  pub received: u64,
 }
 
-impl AthenaContext {
-  pub fn new(address: Address, caller: Address, depth: u32) -> Self {
-    AthenaContext {
-      address,
-      caller,
-      depth,
+#[derive(Debug, Clone)]
+pub struct Caller {
+  pub account: Address,
+  pub template: Option<Address>,
+}
+
+#[derive(Debug)]
+pub struct CallerBuilder {
+  caller: Caller,
+}
+
+impl CallerBuilder {
+  pub fn new(address: Address) -> CallerBuilder {
+    Self {
+      caller: Caller {
+        account: address,
+        template: None,
+      },
     }
   }
 
-  pub fn address(&self) -> &Address {
-    &self.address
+  pub fn build(self) -> Caller {
+    self.caller
   }
 
-  pub fn caller(&self) -> &Address {
-    &self.caller
+  pub fn template(mut self, template: Address) -> Self {
+    self.caller.template = Some(template);
+    self
   }
+}
 
-  pub fn depth(&self) -> u32 {
-    self.depth
+impl AthenaContext {
+  pub fn new(callee: Address, caller: Caller, depth: u32) -> Self {
+    AthenaContext {
+      callee,
+      caller,
+      depth,
+      received: 0,
+    }
   }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, NoUninit)]
+pub struct Context {
+  pub received: u64,
+  pub caller: Address,
+  pub caller_template: Address,
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -19,7 +19,7 @@ pub type Bytes32 = [u8; BYTES32_LENGTH];
 pub type Bytes = [u8];
 
 #[derive(Clone, Debug, Decode, Encode, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MethodSelector([u8; METHOD_SELECTOR_LENGTH]);
+pub struct MethodSelector(pub [u8; METHOD_SELECTOR_LENGTH]);
 
 impl From<&str> for MethodSelector {
   fn from(value: &str) -> Self {

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod context;
 pub mod payload;
+use bytemuck::NoUninit;
 pub use context::*;
 
 pub use parity_scale_codec::{Decode, Encode};
@@ -37,7 +38,8 @@ impl std::fmt::Display for MethodSelector {
   }
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Decode, Encode)]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Decode, Encode, NoUninit)]
 pub struct Address(pub [u8; ADDRESS_LENGTH]);
 
 impl From<&Address> for [u8; ADDRESS_LENGTH] {

--- a/runner/src/vm.rs
+++ b/runner/src/vm.rs
@@ -1,7 +1,7 @@
 use athena_core::runtime::ExecutionError;
 use athena_interface::{
   payload::{ExecutionPayload, Payload},
-  AthenaContext, AthenaMessage, Decode, ExecutionResult, StatusCode,
+  Address, AthenaContext, AthenaMessage, CallerBuilder, Decode, ExecutionResult, StatusCode,
 };
 
 use athena_sdk::{host::HostInterface, AthenaStdin, ExecutionClient};
@@ -56,8 +56,13 @@ impl AthenaVm {
     _rev: AthenaRevision,
     msg: AthenaMessage,
     code: &[u8],
+    caller_template: Address,
   ) -> ExecutionResult {
-    let context = AthenaContext::new(msg.recipient, msg.sender, msg.depth);
+    let caller = CallerBuilder::new(msg.sender)
+      .template(caller_template)
+      .build();
+    let mut context = AthenaContext::new(msg.recipient, caller, msg.depth);
+    context.received = msg.value;
 
     let mut stdin = AthenaStdin::new();
     let execution_payload = match msg
@@ -161,6 +166,7 @@ mod tests {
         Balance::default(),
       ),
       &[],
+      Address::default(),
     );
     assert_eq!(StatusCode::Failure, result.status_code);
   }
@@ -190,6 +196,7 @@ mod tests {
         Balance::default(),
       ),
       elf,
+      Address::default(),
     );
     // this should fail: in noentrypoint mode, this panics.
     assert_eq!(result.status_code, StatusCode::Failure);
@@ -213,6 +220,7 @@ mod tests {
         Balance::default(),
       ),
       elf,
+      Address::default(),
     );
     // this should succeed
     assert_eq!(result.status_code, StatusCode::Success);
@@ -236,6 +244,7 @@ mod tests {
         Balance::default(),
       ),
       elf,
+      Address::default(),
     );
     // this should also succeed
     assert_eq!(result.status_code, StatusCode::Success);
@@ -259,6 +268,7 @@ mod tests {
         Balance::default(),
       ),
       elf,
+      Address::default(),
     );
     // this should fail, as this method is not `callable`
     assert_eq!(result.status_code, StatusCode::Failure);
@@ -273,7 +283,8 @@ mod tests {
     let stdin = AthenaStdin::new();
     let mut host = MockHostInterface::new();
     host.expect_get_balance().return_const(9999u64);
-    let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
+    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let ctx = AthenaContext::new(ADDRESS_ALICE, caller, 0);
     let (mut output, _) = client
       .execute(elf, stdin, Some(&mut host), Some(1000), Some(ctx))
       .unwrap();
@@ -293,7 +304,8 @@ mod tests {
     host
       .expect_call()
       .returning(|_| ExecutionResult::new(StatusCode::CallDepthExceeded, 0, None));
-    let ctx = AthenaContext::new(ADDRESS_ALICE, ADDRESS_ALICE, 0);
+    let caller = CallerBuilder::new(Address([0x88; 24])).build();
+    let ctx = AthenaContext::new(ADDRESS_ALICE, caller, 0);
     let res = client.execute(elf, stdin, Some(&mut host), Some(1_000_000), Some(ctx));
     assert!(matches!(
       res,

--- a/tests/entrypoint/Cargo.lock
+++ b/tests/entrypoint/Cargo.lock
@@ -19,6 +19,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -108,6 +109,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
 
 [[package]]
 name = "byteorder"

--- a/tests/host/tests/host.rs
+++ b/tests/host/tests/host.rs
@@ -1,8 +1,7 @@
 use std::{collections::BTreeMap, error::Error};
 
 use athena_interface::{
-  Address, AthenaContext, AthenaMessage, Balance, Bytes32, CallerBuilder, ExecutionResult,
-  StorageStatus,
+  Address, AthenaContext, AthenaMessage, Balance, Bytes32, Caller, ExecutionResult, StorageStatus,
 };
 use athena_sdk::{host::HostInterface, AthenaStdin, ExecutionClient};
 
@@ -53,7 +52,10 @@ fn test() {
   let stdin = AthenaStdin::new();
   let context = AthenaContext::new(
     Address::from([0xCC; 24]),
-    CallerBuilder::new(Address::default()).build(),
+    Caller {
+      account: Address::default(),
+      template: Address::default(),
+    },
     0,
   );
   let result =

--- a/tests/host/tests/host.rs
+++ b/tests/host/tests/host.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, error::Error};
 
 use athena_interface::{
-  Address, AthenaContext, AthenaMessage, Balance, Bytes32, ExecutionResult, StorageStatus,
+  Address, AthenaContext, AthenaMessage, Balance, Bytes32, CallerBuilder, ExecutionResult,
+  StorageStatus,
 };
 use athena_sdk::{host::HostInterface, AthenaStdin, ExecutionClient};
 
@@ -50,7 +51,11 @@ fn test() {
   let elf = include_bytes!("../elf/host-test");
   let mut host = Host::default();
   let stdin = AthenaStdin::new();
-  let context = AthenaContext::new(Address::from([0xCC; 24]), Address::default(), 0);
+  let context = AthenaContext::new(
+    Address::from([0xCC; 24]),
+    CallerBuilder::new(Address::default()).build(),
+    0,
+  );
   let result =
     ExecutionClient::new().execute(elf, stdin, Some(&mut host), Some(100_000), Some(context));
   // result will be Err if asserts in the test failed

--- a/tests/panic/Cargo.lock
+++ b/tests/panic/Cargo.lock
@@ -19,6 +19,7 @@ name = "athena-interface"
 version = "0.6.3"
 dependencies = [
  "blake3",
+ "bytemuck",
  "hex",
  "parity-scale-codec",
 ]
@@ -82,6 +83,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "byteorder"

--- a/tests/recursive_call/tests/test.rs
+++ b/tests/recursive_call/tests/test.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use athena_interface::{
-  payload::ExecutionPayload, Address, AthenaContext, AthenaMessage, Balance, Bytes32,
-  CallerBuilder, ExecutionResult, StorageStatus,
+  payload::ExecutionPayload, Address, AthenaContext, AthenaMessage, Balance, Bytes32, Caller,
+  ExecutionResult, StorageStatus,
 };
 use athena_runner::{vm::AthenaRevision, AthenaVm};
 use athena_sdk::{host::HostInterface, AthenaStdin, ExecutionClient};
@@ -65,7 +65,10 @@ fn recursive_calling() {
   let mut stdin = AthenaStdin::new();
   let mut host = Host { code: elf.to_vec() };
   let callee = Address::from([0x77; 24]);
-  let caller = CallerBuilder::new(Address([0x88; 24])).build();
+  let caller = Caller {
+    account: Address([0x88; 24]),
+    template: Address::default(),
+  };
   stdin.write(&(callee.as_ref(), 6u32));
 
   let context = AthenaContext::new(callee, caller, 0);
@@ -86,7 +89,10 @@ fn gas_limiting() {
   let mut stdin = AthenaStdin::new();
   let mut host = Host { code: elf.to_vec() };
   let callee = Address::from([0x77; 24]);
-  let caller = CallerBuilder::new(Address([0x88; 24])).build();
+  let caller = Caller {
+    account: Address([0x88; 24]),
+    template: Address::default(),
+  };
   stdin.write(&(callee.as_ref(), 6u32));
 
   let context = AthenaContext::new(callee, caller, 0);

--- a/tests/recursive_call/tests/test.rs
+++ b/tests/recursive_call/tests/test.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use athena_interface::{
   payload::ExecutionPayload, Address, AthenaContext, AthenaMessage, Balance, Bytes32,
-  ExecutionResult, StorageStatus,
+  CallerBuilder, ExecutionResult, StorageStatus,
 };
 use athena_runner::{vm::AthenaRevision, AthenaVm};
 use athena_sdk::{host::HostInterface, AthenaStdin, ExecutionClient};
@@ -38,6 +38,7 @@ impl HostInterface for Host {
       AthenaRevision::AthenaFrontier,
       msg,
       &self.code.clone(),
+      Address::default(),
     )
   }
 
@@ -63,10 +64,11 @@ fn recursive_calling() {
   let elf = include_bytes!("../elf/recursive-call-test");
   let mut stdin = AthenaStdin::new();
   let mut host = Host { code: elf.to_vec() };
-  let template_address = Address::from([0x77; 24]);
-  stdin.write(&(template_address.as_ref(), 6u32));
+  let callee = Address::from([0x77; 24]);
+  let caller = CallerBuilder::new(Address([0x88; 24])).build();
+  stdin.write(&(callee.as_ref(), 6u32));
 
-  let context = AthenaContext::new(template_address, template_address, 0);
+  let context = AthenaContext::new(callee, caller, 0);
   let result =
     ExecutionClient::new().execute(elf, stdin, Some(&mut host), Some(100000000), Some(context));
 
@@ -83,10 +85,11 @@ fn gas_limiting() {
   let elf = include_bytes!("../elf/recursive-call-test");
   let mut stdin = AthenaStdin::new();
   let mut host = Host { code: elf.to_vec() };
-  let template_address = Address::from([0x77; 24]);
-  stdin.write(&(template_address.as_ref(), 6u32));
+  let callee = Address::from([0x77; 24]);
+  let caller = CallerBuilder::new(Address([0x88; 24])).build();
+  stdin.write(&(callee.as_ref(), 6u32));
 
-  let context = AthenaContext::new(template_address, template_address, 0);
+  let context = AthenaContext::new(callee, caller, 0);
   let result =
     ExecutionClient::new().execute(elf, stdin, Some(&mut host), Some(100), Some(context));
   assert!(result.is_err());

--- a/vm/entrypoint/src/program.rs
+++ b/vm/entrypoint/src/program.rs
@@ -88,6 +88,26 @@ where
   }
 }
 
+/// Implement Method for methods taking 0 arguments:
+/// # Example:
+/// ```ignore
+/// impl Foo {
+///   fn foo(&self) -> impl IntoResult<IO>
+/// }
+/// ```
+impl<F, IO, S, R> Method<(&S,), R, IO> for F
+where
+  IO: Read + Write,
+  F: Fn(&S) -> R,
+  S: IntoArgument<S, IO>,
+  R: IntoResult<IO>,
+{
+  fn call_method(self, io: &mut IO) {
+    let method = S::into_argument(io);
+    self(&method).into_result(io);
+  }
+}
+
 /// Implement Method for methods taking 1 argument:
 /// # Example:
 /// ```ignore

--- a/vm/entrypoint/src/syscalls/context.rs
+++ b/vm/entrypoint/src/syscalls/context.rs
@@ -1,13 +1,6 @@
 use std::mem::MaybeUninit;
 
-use athena_interface::Address;
-
-#[repr(C)]
-pub struct Context {
-  pub received: u64,
-  pub caller: Address,
-  pub caller_template: Address,
-}
+use athena_interface::Context;
 
 pub fn context() -> Context {
   let ctx = MaybeUninit::<Context>::uninit();

--- a/vm/entrypoint/src/syscalls/context.rs
+++ b/vm/entrypoint/src/syscalls/context.rs
@@ -1,0 +1,24 @@
+use std::mem::MaybeUninit;
+
+use athena_interface::Address;
+
+#[repr(C)]
+pub struct Context {
+  pub received: u64,
+  pub caller: Address,
+  pub caller_template: Address,
+}
+
+pub fn context() -> Context {
+  let ctx = MaybeUninit::<Context>::uninit();
+  #[cfg(target_os = "zkvm")]
+  unsafe {
+    core::arch::asm!(
+        "ecall",
+        in("t0") crate::syscalls::HOST_CONTEXT,
+        in("a0") ctx.as_ptr(),
+    );
+  }
+  // SAFETY: the host initialized it.
+  unsafe { ctx.assume_init() }
+}

--- a/vm/entrypoint/src/syscalls/mod.rs
+++ b/vm/entrypoint/src/syscalls/mod.rs
@@ -4,8 +4,8 @@ mod io;
 mod memory;
 mod sys;
 
+pub mod context;
 pub mod precompiles;
-
 pub use halt::*;
 pub use host::*;
 pub use io::*;
@@ -37,3 +37,4 @@ pub const HOST_CALL: u32 = 0x00_00_00_A2;
 pub const HOST_GETBALANCE: u32 = 0x00_00_00_A3;
 pub const HOST_SPAWN: u32 = 0x00_00_00_A4;
 pub const HOST_DEPLOY: u32 = 0x00_00_00_A5;
+pub const HOST_CONTEXT: u32 = 0x00_00_00_A6;


### PR DESCRIPTION
Example contracts implementing a custom token. It features 2 contracts:

### Mint
It allows exchanging SMH for the token, which is then transferred to the chosen wallet address.
                                         
Every mint account instance represents a unique token.

### Token wallet
It keeps and allows spending various tokens created by different mints. 
Every mint instance creates a unique token, which is identified by the address of the mint.
 
---

The contracts are simplistic and could be further extended and improved. For example:
- the mint has a constant exchange ratio (it's part of the immutable state)
- it's not possible to trade tokens back to SMH:w

---

Additionally, this PR extends the `AthenaContext` to keep:
- the caller template, which is needed for the token wallet to identify the caller (it must be either mint or wallet contract)
- the SMH transferred with the call, which is needed for the mint `buy()` to know how much SMH it received
