### PR TITLE
add parentheses to fix clippy warning

### DIFF
--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -1015,7 +1015,10 @@ pub mod tests {
     // check result: we expect the u64 value to be split into two 32-bit words
     let value_low = runtime.mr(memloc);
     let value_high = runtime.mr(memloc + 4);
-    assert_eq!(u64::from(value_high) << 32 | u64::from(value_low), 1111u64);
+    assert_eq!(
+      (u64::from(value_high) << 32) | u64::from(value_low),
+      1111u64
+    );
   }
 
   #[test]

--- a/core/src/runtime/syscall.rs
+++ b/core/src/runtime/syscall.rs
@@ -141,7 +141,7 @@ impl<'a, 'h> SyscallContext<'a, 'h> {
 
   pub fn dword(&self, addr: u32) -> u64 {
     assert_eq!(addr % 4, 0);
-    self.word(addr) as u64 | (self.word(addr + 4) as u64) << 32
+    self.word(addr) as u64 | ((self.word(addr + 4) as u64) << 32)
   }
 
   pub fn slice(&self, addr: u32, len: usize) -> Vec<u32> {


### PR DESCRIPTION
Fixes

```
error: operator precedence can trip the unwary
Error:    --> core/src/runtime/syscall.rs:144:5
    |
144 |     self.word(addr) as u64 | (self.word(addr + 4) as u64) << 32
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `self.word(addr) as u64 | ((self.word(addr + 4) as u64) << 32)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
```